### PR TITLE
fix(website): Fixed CSS in overview page

### DIFF
--- a/apps/website/docs/getting-started/overview.mdx
+++ b/apps/website/docs/getting-started/overview.mdx
@@ -18,7 +18,7 @@ For example, comparing the button components:
 
 export function ComponentComparison() {
   return (
-    <DisplayStand className="mb-5 grid grid-cols-1 gap-4 border-none p-0 min-[375px]:grid-cols-2">
+    <DisplayStand className="mb-5 grid grid-cols-1 gap-4 border-none p-0 dark:bg-transparent min-[375px]:grid-cols-2">
       <DisplayStand className="grid items-start justify-start gap-y-0">
         <CssVarsProvider modeStorageKey="theme">
           <h3>Joy UI</h3>


### PR DESCRIPTION
## Summary

This website includes a `DisplayStand` component for displaying Tailwind-Joy component demos.

The overview page has this component nested, but I wanted to visually make it look like the outer `DisplayStand` wasn't there.

In the process, I add the missing dark mode background color handling.

This PR closes #2.