### PR TITLE
build(core): Exports the type of CJS module

### DIFF
--- a/packages/tailwind-joy/vite.config.mjs
+++ b/packages/tailwind-joy/vite.config.mjs
@@ -1,3 +1,4 @@
+import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
@@ -22,6 +23,17 @@ export default defineConfig({
     dts({
       entryRoot: 'src',
       include: ['src/**'],
+      afterBuild(emittedFiles) {
+        for (const [path, code] of emittedFiles) {
+          const extensionReplacedPath = path.replace(/\.d\.ts$/, '.d.cts');
+          const extensionAddedCode = code.replace(
+            /(from '\.?\.(?:\/[^/;]+)*\/[^/;.]+)(';)/g,
+            '$1.cjs$2',
+          );
+
+          writeFileSync(extensionReplacedPath, extensionAddedCode);
+        }
+      },
     }),
     react(),
     safelistGenerator(),


### PR DESCRIPTION
## Summary

Tailwind-Joy exports modules in a format that supports both CJS and ESM.

However, because the type declaration corresponding to the CJS module was missing, there was a problem in which type information could not be detected in an environment where components were imported through the CJS module.

This PR closes #1.