### PR TITLE
fix(core): Applies the style property provided by the user to the circular progress component

### DIFF
--- a/packages/tailwind-joy/src/components/CircularProgress.tsx
+++ b/packages/tailwind-joy/src/components/CircularProgress.tsx
@@ -390,6 +390,7 @@ export const CircularProgress = forwardRef<
   {
     children,
     className,
+    style,
     color = 'primary',
     size,
     variant = 'soft',
@@ -417,6 +418,7 @@ export const CircularProgress = forwardRef<
       {...otherProps}
       // @ts-ignore
       style={{
+        ...style,
         ...(thickness === undefined
           ? {}
           : {


### PR DESCRIPTION
## Summary

The `CircularProgress` component has CSS variables assigned to its `style` property depending on the presence of the `thickness` and `value` properties.

However, I forgot to spread the `style` property provided to the component.

This PR closes #9.