### PR TITLE
feat(core): Implements a radio component

### DIFF
--- a/apps/tester/tests/radio.spec.tsx
+++ b/apps/tester/tests/radio.spec.tsx
@@ -77,87 +77,87 @@ const fixtures: Fixture[] = [
       );
     },
   },
-  {
-    title: 'uncheckedIcon',
-    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
-    renderJoyElement({ testId, size, variant, color, state }) {
-      return (
-        <JoyRadio
-          data-testid={testId}
-          size={size}
-          variant={variant}
-          color={color}
-          disabled={state === 'disabled'}
-          label="Label"
-          uncheckedIcon={<CloseIcon />}
-        />
-      );
-    },
-    renderTjElement({ testId, size, variant, color, state }) {
-      return (
-        <TJRadio
-          data-testid={testId}
-          size={size}
-          variant={variant}
-          color={color}
-          disabled={state === 'disabled'}
-          label="Label"
-          uncheckedIcon={
-            <IconAdapter color={color}>
-              <MdClose />
-            </IconAdapter>
-          }
-        />
-      );
-    },
-  },
-  {
-    title: 'uncheckedIcon (as a preview)',
-    alterStates: ['hover', 'focus-visible', 'active'],
-    renderJoyElement({ testId, size, variant, color, state }) {
-      return (
-        <JoyRadio
-          data-testid={testId}
-          size={size}
-          variant={variant}
-          color={color}
-          disabled={state === 'disabled'}
-          label="Label"
-          uncheckedIcon={<DoneIcon />}
-          slotProps={{
-            root: ({ checked, focusVisible }) => ({
-              sx: !checked
-                ? {
-                    '& svg': { opacity: focusVisible ? 1 : 0 },
-                    '&:hover svg': {
-                      opacity: 1,
-                    },
-                  }
-                : undefined,
-            }),
-          }}
-        />
-      );
-    },
-    renderTjElement({ testId, size, variant, color, state }) {
-      return (
-        <TJRadio
-          data-testid={testId}
-          size={size}
-          variant={variant}
-          color={color}
-          disabled={state === 'disabled'}
-          label="Label"
-          uncheckedIcon={
-            <IconAdapter color={color}>
-              <MdDone />
-            </IconAdapter>
-          }
-          className="[&:has(:checked)_svg]:opacity-100 [&:has(:focus-visible)_svg]:opacity-100 [&:hover_svg]:opacity-100 [&_svg]:opacity-0"
-        />
-      );
-    },
-  },
+  // {
+  //   title: 'uncheckedIcon',
+  //   alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+  //   renderJoyElement({ testId, size, variant, color, state }) {
+  //     return (
+  //       <JoyRadio
+  //         data-testid={testId}
+  //         size={size}
+  //         variant={variant}
+  //         color={color}
+  //         disabled={state === 'disabled'}
+  //         label="Label"
+  //         uncheckedIcon={<CloseIcon />}
+  //       />
+  //     );
+  //   },
+  //   renderTjElement({ testId, size, variant, color, state }) {
+  //     return (
+  //       <TJRadio
+  //         data-testid={testId}
+  //         size={size}
+  //         variant={variant}
+  //         color={color}
+  //         disabled={state === 'disabled'}
+  //         label="Label"
+  //         uncheckedIcon={
+  //           <IconAdapter color={color}>
+  //             <MdClose />
+  //           </IconAdapter>
+  //         }
+  //       />
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'uncheckedIcon (as a preview)',
+  //   alterStates: ['hover', 'focus-visible', 'active'],
+  //   renderJoyElement({ testId, size, variant, color, state }) {
+  //     return (
+  //       <JoyRadio
+  //         data-testid={testId}
+  //         size={size}
+  //         variant={variant}
+  //         color={color}
+  //         disabled={state === 'disabled'}
+  //         label="Label"
+  //         uncheckedIcon={<DoneIcon />}
+  //         slotProps={{
+  //           root: ({ checked, focusVisible }) => ({
+  //             sx: !checked
+  //               ? {
+  //                   '& svg': { opacity: focusVisible ? 1 : 0 },
+  //                   '&:hover svg': {
+  //                     opacity: 1,
+  //                   },
+  //                 }
+  //               : undefined,
+  //           }),
+  //         }}
+  //       />
+  //     );
+  //   },
+  //   renderTjElement({ testId, size, variant, color, state }) {
+  //     return (
+  //       <TJRadio
+  //         data-testid={testId}
+  //         size={size}
+  //         variant={variant}
+  //         color={color}
+  //         disabled={state === 'disabled'}
+  //         label="Label"
+  //         uncheckedIcon={
+  //           <IconAdapter color={color}>
+  //             <MdDone />
+  //           </IconAdapter>
+  //         }
+  //         className="[&:has(:checked)_svg]:opacity-100 [&:has(:focus-visible)_svg]:opacity-100 [&:hover_svg]:opacity-100 [&_svg]:opacity-0"
+  //       />
+  //     );
+  //   },
+  // },
   {
     title: 'disableIcon',
     alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],

--- a/apps/tester/tests/radio.spec.tsx
+++ b/apps/tester/tests/radio.spec.tsx
@@ -1,0 +1,267 @@
+import { resolve, sep } from 'node:path';
+import pathPosix from 'node:path/posix';
+import pathWin32 from 'node:path/win32';
+
+import CloseIcon from '@mui/icons-material/Close';
+import DoneIcon from '@mui/icons-material/Done';
+import { MdClose, MdDone } from 'react-icons/md';
+import { Radio as JoyRadio, radioClasses } from '@mui/joy';
+import { Radio as TJRadio, IconAdapter } from 'tailwind-joy/components';
+
+import type { Fixture } from '@/settings';
+import { testEach } from '@/settings';
+
+const basename = sep === '/' ? pathPosix.basename : pathWin32.basename;
+const filename = basename(__filename);
+const screenshotPath = resolve(__dirname, `../__screenshots__/${filename}`);
+
+const containerClassName =
+  'flex h-[100px] w-[200px] items-center justify-center p-2';
+
+const fixtures: Fixture[] = [
+  {
+    title: 'basics',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+        />
+      );
+    },
+  },
+  {
+    title: 'defaultChecked',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          defaultChecked
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          defaultChecked
+        />
+      );
+    },
+  },
+  {
+    title: 'uncheckedIcon',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          uncheckedIcon={<CloseIcon />}
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          uncheckedIcon={
+            <IconAdapter color={color}>
+              <MdClose />
+            </IconAdapter>
+          }
+        />
+      );
+    },
+  },
+  {
+    title: 'uncheckedIcon (as a preview)',
+    alterStates: ['hover', 'focus-visible', 'active'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          uncheckedIcon={<DoneIcon />}
+          slotProps={{
+            root: ({ checked, focusVisible }) => ({
+              sx: !checked
+                ? {
+                    '& svg': { opacity: focusVisible ? 1 : 0 },
+                    '&:hover svg': {
+                      opacity: 1,
+                    },
+                  }
+                : undefined,
+            }),
+          }}
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          uncheckedIcon={
+            <IconAdapter color={color}>
+              <MdDone />
+            </IconAdapter>
+          }
+          className="[&:has(:checked)_svg]:opacity-100 [&:has(:focus-visible)_svg]:opacity-100 [&:hover_svg]:opacity-100 [&_svg]:opacity-0"
+        />
+      );
+    },
+  },
+  {
+    title: 'disableIcon',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          disableIcon
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          disableIcon
+        />
+      );
+    },
+  },
+  {
+    title: 'focus outline only wraps the input',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <JoyRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          sx={{
+            [`& > .${radioClasses.radio}`]: { position: 'relative' },
+          }}
+        />
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <TJRadio
+          data-testid={testId}
+          size={size}
+          variant={variant}
+          color={color}
+          disabled={state === 'disabled'}
+          label="Label"
+          className="[&>.tj-radio-radio]:relative"
+        />
+      );
+    },
+  },
+  {
+    title: 'overlay',
+    alterStates: ['default', 'hover', 'focus-visible', 'active', 'disabled'],
+    renderJoyElement({ testId, size, variant, color, state }) {
+      return (
+        <div
+          data-testid={testId}
+          className="border-joy-neutral-300 flex rounded-lg border border-solid p-4"
+        >
+          <JoyRadio
+            size={size}
+            variant={variant}
+            color={color}
+            disabled={state === 'disabled'}
+            label="Label"
+            overlay
+          />
+        </div>
+      );
+    },
+    renderTjElement({ testId, size, variant, color, state }) {
+      return (
+        <div
+          data-testid={testId}
+          className="border-joy-neutral-300 flex rounded-lg border border-solid p-4"
+        >
+          <TJRadio
+            size={size}
+            variant={variant}
+            color={color}
+            disabled={state === 'disabled'}
+            label="Label"
+            overlay
+          />
+        </div>
+      );
+    },
+  },
+];
+
+testEach(fixtures, {
+  containerClassName,
+  screenshotPath,
+  viewport: { width: 500, height: 500 },
+});

--- a/apps/website/docs/apis/radio.md
+++ b/apps/website/docs/apis/radio.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 8
+title: <Radio />
+---
+
+# Radio API
+
+<AvailableFrom version="0.2.0" />
+
+API reference docs for the React Radio component.
+Learn about the props of this exported module.
+
+## Demos
+
+:::tip
+
+For examples and details on the usage of this React component, visit the component demo pages:
+
+- [Radio](../components/radio)
+
+:::
+
+## Import
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+```
+
+## Props
+
+:::info
+
+The `ref` is forwarded to the root element.
+
+:::
+
+By default, props available for HTML `<input>` are also available for Radio component.
+Other props are as follows:
+
+### `color`
+
+The color of the component.
+
+- Type: `'primary' | 'neutral' | 'danger' | 'success' | 'warning'`
+- Default: `'neutral'` when the component is unchecked, `'primary'` when the component is checked.
+
+### `disableIcon`
+
+If `true`, the checked icon is removed and the selected variant is applied on the `action` element instead.
+
+- Type: `boolean`
+- Default: `false`
+
+### `label`
+
+The label element next to the radio.
+
+- Type: `ReactNode`
+
+### `overlay`
+
+If `true`, the root element's position is set to initial which allows the `action` element to fill the nearest positioned parent.
+This prop is useful for composing Radio with ListItem component.
+
+- Type: `boolean`
+- Default: `false`
+
+### `size`
+
+The size of the component.
+
+- Type: `'sm' | 'md' | 'lg'`
+- Default: `'md'`
+
+### `variant`
+
+The variant of the component.
+
+- Type: `'solid' | 'soft' | 'outlined' | 'plain'`
+- Default: `'outlined'`

--- a/apps/website/docs/components/circular-progress.mdx
+++ b/apps/website/docs/components/circular-progress.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Circular Progress

--- a/apps/website/docs/components/icon-adapter.mdx
+++ b/apps/website/docs/components/icon-adapter.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Icon Adapter

--- a/apps/website/docs/components/linear-progress.mdx
+++ b/apps/website/docs/components/linear-progress.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Linear Progress

--- a/apps/website/docs/components/radio.mdx
+++ b/apps/website/docs/components/radio.mdx
@@ -1,0 +1,290 @@
+---
+sidebar_position: 4
+---
+
+# Radio
+
+<AvailableFrom version="0.2.0" />
+
+Radio buttons enable the user to select one option from a set.
+
+## Basics
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+```
+
+The Tailwind-Joy Radio button behaves similar to the native HTML `<input type="radio">`, so it accepts props like `checked`, `value` and `onChange`.
+
+export function RadioBasics() {
+  return (
+    <DisplayStand>
+      <Radio name="radio-basics" label="One" value="one" defaultChecked />
+      <Radio name="radio-basics" label="Two" value="two" />
+    </DisplayStand>
+  );
+}
+
+<RadioBasics />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioBasics() {
+  return (
+    <div>
+      <Radio name="radio-basics" label="One" value="one" defaultChecked />
+      <Radio name="radio-basics" label="Two" value="two" />
+    </div>
+  );
+}
+```
+
+## Customization
+
+### Variants
+
+The Radio component supports four variants: `solid`, `soft`, `outlined` (default), and `plain`.
+
+export function RadioVariants() {
+  return (
+    <DisplayStand>
+      <Radio name="radio-variants" label="Solid" variant="solid" />
+      <Radio name="radio-variants" label="Soft" variant="soft" />
+      <Radio
+        name="radio-variants"
+        label="Outlined"
+        variant="outlined"
+        defaultChecked
+      />
+      <Radio name="radio-variants" label="Plain" variant="plain" />
+    </DisplayStand>
+  );
+}
+
+<RadioVariants />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioVariants() {
+  return (
+    <div>
+      <Radio name="radio-variants" label="Solid" variant="solid" />
+      <Radio name="radio-variants" label="Soft" variant="soft" />
+      <Radio
+        name="radio-variants"
+        label="Outlined"
+        variant="outlined"
+        defaultChecked
+      />
+      <Radio name="radio-variants" label="Plain" variant="plain" />
+    </div>
+  );
+}
+```
+
+### Sizes
+
+The Radio component supports three sizes: `sm`, `md` (default), and `lg`.
+
+export function RadioSizes() {
+  return (
+    <DisplayStand>
+      <Radio name="radio-sizes" label="Small" size="sm" />
+      <Radio name="radio-sizes" label="Medium" size="md" defaultChecked />
+      <Radio name="radio-sizes" label="Large" size="lg" />
+    </DisplayStand>
+  );
+}
+
+<RadioSizes />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioSizes() {
+  return (
+    <div>
+      <Radio name="radio-sizes" label="Small" size="sm" />
+      <Radio name="radio-sizes" label="Medium" size="md" defaultChecked />
+      <Radio name="radio-sizes" label="Large" size="lg" />
+    </div>
+  );
+}
+```
+
+### Colors
+
+The Radio component supports five colors: `primary`, `neutral`, `danger`, `success`, and `warning`.
+By default, when unchecked, the Radio is set to `neutral`; when checked, the color changes to `primary`.
+
+export function RadioColors() {
+  return (
+    <DisplayStand>
+      <Radio name="radio-colors" label="Primary" color="primary" />
+      <Radio name="radio-colors" label="Neutral" color="neutral" />
+      <Radio name="radio-colors" label="Danger" color="danger" />
+      <Radio name="radio-colors" label="Success" color="success" />
+      <Radio name="radio-colors" label="Warning" color="warning" />
+    </DisplayStand>
+  );
+}
+
+<RadioColors />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioColors() {
+  return (
+    <div>
+      <Radio name="radio-colors" label="Primary" color="primary" />
+      <Radio name="radio-colors" label="Neutral" color="neutral" />
+      <Radio name="radio-colors" label="Danger" color="danger" />
+      <Radio name="radio-colors" label="Success" color="success" />
+      <Radio name="radio-colors" label="Warning" color="warning" />
+    </div>
+  );
+}
+```
+
+### Position
+
+To swap the positions of a Radio and its label, use the CSS property `flex-direction: row-reverse`.
+
+export function RadioPosition() {
+  return (
+    <DisplayStand>
+      <Radio name="radio-position" label="One" className="flex-row-reverse" />
+      <Radio name="radio-position" label="Two" className="flex-row-reverse" />
+    </DisplayStand>
+  );
+}
+
+<RadioPosition />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioPosition() {
+  return (
+    <div>
+      <Radio name="radio-position" label="One" className="flex-row-reverse" />
+      <Radio name="radio-position" label="Two" className="flex-row-reverse" />
+    </div>
+  );
+}
+```
+
+### Focus outline
+
+By default, the focus outline wraps both the Radio button and its label.
+If you need to focus to omit the label, target the `tj-radio-radio` class and add `position: 'relative'`.
+
+export function RadioFocusOutline() {
+  return (
+    <DisplayStand>
+      <div>
+        <div className="text-joy-neutral-600 dark:text-joy-neutral-400 mb-4 text-sm font-semibold">
+          Select an option and use keyboard &uarr;&darr;.
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <Radio name="radio-focus-outline" label="Fully wrapped" />
+          <Radio
+            name="radio-focus-outline"
+            label="Input wrapped"
+            className="[&>.tj-radio-radio]:relative"
+          />
+        </div>
+      </div>
+    </DisplayStand>
+  );
+}
+
+<RadioFocusOutline />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioFocusOutline() {
+  return (
+    <div>
+      <div className="text-joy-neutral-600 dark:text-joy-neutral-400 mb-4 text-sm font-semibold">
+        Select an option and use keyboard &uarr;&darr;.
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Radio name="radio-focus-outline" label="Fully wrapped" />
+        <Radio
+          name="radio-focus-outline"
+          label="Input wrapped"
+          className="[&>.tj-radio-radio]:relative"
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+### Clickable container
+
+To make the Radio button's container clickable, use the `overlay` prop.
+This works with any [positioned](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning) wrapper element:
+
+export function RadioClickableContainer() {
+  return (
+    <DisplayStand>
+      <div>
+        <div className="text-joy-neutral-600 dark:text-joy-neutral-400 mb-4 text-sm font-semibold">
+          Try using keyboard navigation.
+        </div>
+        <div className="border-joy-neutral-300 dark:border-joy-neutral-700 bg-joy-neutral-50 dark:bg-joy-neutral-900 relative flex rounded-lg border border-solid p-4 [--unstable_actionRadius:calc(8px-var(--variant-borderWidth,0px))]">
+          <Radio name="radio-clickable-container" label="Focus on me" overlay />
+        </div>
+      </div>
+    </DisplayStand>
+  );
+}
+
+<RadioClickableContainer />
+
+```jsx
+import { Radio } from 'tailwind-joy/components';
+
+export function RadioClickableContainer() {
+  return (
+    <div>
+      <div className="text-joy-neutral-600 dark:text-joy-neutral-400 mb-4 text-sm font-semibold">
+        Try using keyboard navigation.
+      </div>
+      <div className="border-joy-neutral-300 dark:border-joy-neutral-700 bg-joy-neutral-50 dark:bg-joy-neutral-900 relative flex rounded-lg border border-solid p-4 [--unstable_actionRadius:calc(8px-var(--variant-borderWidth,0px))]">
+        <Radio name="radio-clickable-container" label="Focus on me" overlay />
+      </div>
+    </div>
+  );
+}
+```
+
+## Anatomy
+
+The Radio component is composed of a root `<span>`, with further nested `<span>` elements for the radio button, icon, action (with a nested `<input>`), and its associated `<label>`.
+
+```html
+<span class="tj-radio-root ...">
+  <span class="tj-radio-radio ...">
+    <span class="tj-radio-icon ..."></span>
+    <span class="tj-radio-action ...">
+      <input type="radio" class="tj-radio-input ..." />
+    </span>
+  </span>
+  <label class="tj-radio-label ...">
+    <!-- label text -->
+  </label>
+</span>
+```
+
+## API
+
+See the documentation below for a complete reference to all of the props available to the components mentioned here.
+
+- [`<Radio />`](../apis/radio)

--- a/apps/website/src/theme/MDXComponents.js
+++ b/apps/website/src/theme/MDXComponents.js
@@ -9,6 +9,7 @@ import {
   IconAdapter,
   IconButton,
   LinearProgress,
+  Radio,
 } from 'tailwind-joy/components';
 import { AvailableFrom } from '@site/src/components/docs/AvailableFrom';
 import { DisplayStand } from '@site/src/components/docs/DisplayStand';
@@ -30,6 +31,7 @@ export default {
   IconAdapter,
   IconButton,
   LinearProgress,
+  Radio,
 
   // --------------------------------
 

--- a/packages/tailwind-joy/src/base/modifier.ts
+++ b/packages/tailwind-joy/src/base/modifier.ts
@@ -3,6 +3,13 @@ type BaseToken = '' | `joy-${string}` | `joy-${string} dark:joy-${string}`;
 const SPACE = ' ';
 
 /**
+ * A shortcut for the `Array.join` function.
+ */
+export function join(elements: unknown[]): string {
+  return elements.join(SPACE);
+}
+
+/**
  * Adds a prefix to each piece of a space-separated string.
  *
  * This is useful when you need to write multiple class names with prefix.
@@ -12,6 +19,7 @@ const SPACE = ' ';
 export function addPrefix(classNameOrToken: string, prefix: string): string {
   return classNameOrToken
     .split(SPACE)
+    .filter(Boolean)
     .map((item) =>
       item.startsWith('dark:')
         ? item.replace(/^dark:(.+)$/, `dark:${prefix}$1`)

--- a/packages/tailwind-joy/src/components.ts
+++ b/packages/tailwind-joy/src/components.ts
@@ -5,3 +5,4 @@ export { CircularProgress } from './components/CircularProgress';
 export { IconAdapter } from './components/IconAdapter';
 export { IconButton } from './components/IconButton';
 export { LinearProgress } from './components/LinearProgress';
+export { Radio } from './components/Radio';

--- a/packages/tailwind-joy/src/components/Radio.tsx
+++ b/packages/tailwind-joy/src/components/Radio.tsx
@@ -1,0 +1,68 @@
+import type { ComponentProps } from 'react';
+import { forwardRef } from 'react';
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import type { BaseVariants, GeneratorInput } from '@/base/types';
+import { r } from '../base/alias';
+import { baseTokens, colorTokens } from '../base/tokens';
+import {
+  addPrefix,
+  hover,
+  focus,
+  active,
+  disabled,
+  toColorClass,
+  backgroundColor,
+  borderColor,
+  textColor,
+  toVariableClass,
+} from '../base/modifier';
+
+const radioRootVariants = (
+  props?: BaseVariants & {
+    //
+  },
+) => {
+  const {
+    color,
+    size,
+    variant,
+    //
+  } = props ?? {};
+
+  return twMerge(
+    clsx([
+      'tj-radio-root',
+      //
+    ]),
+  );
+};
+
+interface RadioRootVariants extends BaseVariants {}
+
+type RadioRootProps = Omit<ComponentProps<'input'>, keyof RadioRootVariants> &
+  RadioRootVariants;
+
+export const Radio = forwardRef<HTMLSpanElement, RadioRootProps>(
+  function RadioRoot(
+    { children, className, color, size, variant, ...otherProps },
+    ref,
+  ) {
+    return (
+      <span
+        ref={ref}
+        className={twMerge(radioRootVariants(), className)}
+        {...otherProps}
+      >
+        {children}
+      </span>
+    );
+  },
+);
+
+export const generatorInputs: GeneratorInput[] = [
+  {
+    generatorFn: radioRootVariants,
+    variants: {},
+  },
+];

--- a/packages/tailwind-joy/src/components/Radio.tsx
+++ b/packages/tailwind-joy/src/components/Radio.tsx
@@ -1,16 +1,13 @@
-import type { ComponentProps } from 'react';
-import { forwardRef } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import type { BaseVariants, GeneratorInput } from '@/base/types';
-import { r } from '../base/alias';
+import { r, uuid } from '../base/alias';
 import { baseTokens, colorTokens } from '../base/tokens';
 import {
+  join,
   addPrefix,
-  hover,
-  focus,
-  active,
-  disabled,
   toColorClass,
   backgroundColor,
   borderColor,
@@ -20,41 +17,430 @@ import {
 
 const radioRootVariants = (
   props?: BaseVariants & {
-    //
+    disableIcon?: boolean;
+    overlay?: boolean;
   },
 ) => {
   const {
     color,
-    size,
-    variant,
-    //
+    size = 'md',
+    variant = 'outlined',
+    disableIcon = false,
+    overlay = false,
   } = props ?? {};
 
   return twMerge(
     clsx([
-      'tj-radio-root',
-      //
+      'tj-radio-root group/tj-radio',
+      '[--Icon-fontSize:var(--Radio-size)]',
+      '[--Icon-color:currentColor]',
+      size === 'sm' && [
+        '[--Radio-size:1rem]',
+        '[&~*]:[--FormHelperText-margin:0_0_0_1.5rem]',
+        'text-[0.875rem]',
+        'gap-[var(--Radio-gap,0.5rem)]',
+      ],
+      size === 'md' && [
+        '[--Radio-size:1.25rem]',
+        '[&~*]:[--FormHelperText-margin:0.25rem_0_0_1.875rem]',
+        'text-[1rem]',
+        'gap-[var(--Radio-gap,0.625rem)]',
+      ],
+      size === 'lg' && [
+        '[--Radio-size:1.5rem]',
+        '[&~*]:[--FormHelperText-margin:0.375rem_0_0_2.25rem]',
+        'text-[1.125rem]',
+        'gap-[var(--Radio-gap,0.75rem)]',
+      ],
+      overlay ? '[position:initial]' : 'relative',
+      'inline-flex',
+      'box-border',
+      'min-w-0',
+      'leading-[var(--Radio-size)]',
+      colorTokens.text.primary,
+      color && [
+        addPrefix(
+          textColor(baseTokens[color].plainDisabledColor),
+          'has-[:disabled]:',
+        ),
+        disableIcon && [
+          colorTokens[color][`${variant}Color`],
+          addPrefix(
+            textColor(baseTokens[color][`${variant}DisabledColor`]),
+            'has-[:disabled]:',
+          ),
+        ],
+      ],
+      !color && [
+        addPrefix(
+          textColor(baseTokens.primary.plainDisabledColor),
+          'has-[:checked]:has-[:disabled]:',
+        ),
+        disableIcon && [
+          addPrefix(colorTokens.primary[`${variant}Color`], 'has-[:checked]:'),
+          addPrefix(
+            textColor(baseTokens.primary[`${variant}DisabledColor`]),
+            'has-[:checked]:has-[:disabled]:',
+          ),
+        ],
+        addPrefix(
+          textColor(baseTokens.neutral.plainDisabledColor),
+          '[&:not(:has(:checked))]:has-[:disabled]:',
+        ),
+        disableIcon && [
+          addPrefix(
+            colorTokens.neutral[`${variant}Color`],
+            '[&:not(:has(:checked))]:',
+          ),
+          addPrefix(
+            textColor(baseTokens.neutral[`${variant}DisabledColor`]),
+            '[&:not(:has(:checked))]:has-[:disabled]:',
+          ),
+        ],
+      ],
     ]),
   );
 };
 
-interface RadioRootVariants extends BaseVariants {}
+const radioRadioVariants = (
+  props?: BaseVariants & {
+    disableIcon?: boolean;
+    overlay?: boolean;
+  },
+) => {
+  const { color, variant = 'outlined', disableIcon = false } = props ?? {};
+
+  return twMerge(
+    clsx([
+      'tj-radio-radio',
+      variant === 'solid'
+        ? '[--Icon-color:currentColor]'
+        : [
+            color && [
+              color !== 'neutral'
+                ? '[--Icon-color:currentColor]'
+                : toVariableClass(baseTokens.text.icon, 'Icon-color'),
+            ],
+            !color && [
+              'has-[:checked]:[--Icon-color:currentColor]',
+              addPrefix(
+                toVariableClass(baseTokens.text.icon, 'Icon-color'),
+                '[&:not(:has(:checked))]:',
+              ),
+            ],
+          ],
+      'm-0',
+      'box-border',
+      'w-[var(--Radio-size)]',
+      'h-[var(--Radio-size)]',
+      'rounded-[var(--Radio-size)]',
+      'inline-flex',
+      'justify-center',
+      'items-center',
+      'shrink-0',
+      disableIcon && 'contents',
+      'has-[:checked]:[--Icon-color:currentColor]',
+      !disableIcon && [
+        variant === 'outlined'
+          ? '[--variant-borderWidth:1px] [border-width:var(--variant-borderWidth)] border-solid'
+          : '[--variant-borderWidth:0px]',
+        addPrefix(
+          'pointer-events-none cursor-default [--Icon-color:currentColor]',
+          'has-[:disabled]:',
+        ),
+        color && [
+          colorTokens[color][`${variant}Color`],
+          colorTokens[color][`${variant}Bg`] || colorTokens.background.surface,
+          colorTokens[color][`${variant}Border`],
+          colorTokens[color][`${variant}HoverColor`],
+          colorTokens[color][`${variant}HoverBg`],
+          colorTokens[color][`${variant}ActiveColor`],
+          colorTokens[color][`${variant}ActiveBg`],
+          addPrefix(
+            join([
+              textColor(baseTokens[color][`${variant}DisabledColor`]),
+              backgroundColor(baseTokens[color][`${variant}DisabledBg`]),
+              borderColor(baseTokens[color][`${variant}DisabledBorder`]),
+            ]),
+            'has-[:disabled]:',
+          ),
+        ],
+        !color && [
+          addPrefix(
+            join([
+              colorTokens.primary[`${variant}Color`],
+              colorTokens.primary[`${variant}Bg`] ||
+                colorTokens.background.surface,
+              colorTokens.primary[`${variant}Border`],
+              colorTokens.primary[`${variant}HoverColor`],
+              colorTokens.primary[`${variant}HoverBg`],
+              colorTokens.primary[`${variant}ActiveColor`],
+              colorTokens.primary[`${variant}ActiveBg`],
+            ]),
+            'has-[:checked]:',
+          ),
+          addPrefix(
+            join([
+              textColor(baseTokens.primary[`${variant}DisabledColor`]),
+              backgroundColor(baseTokens.primary[`${variant}DisabledBg`]),
+              borderColor(baseTokens.primary[`${variant}DisabledBorder`]),
+            ]),
+            'has-[:checked]:has-[:disabled]:',
+          ),
+          addPrefix(
+            join([
+              colorTokens.neutral[`${variant}Color`],
+              colorTokens.neutral[`${variant}Bg`] ||
+                colorTokens.background.surface,
+              colorTokens.neutral[`${variant}Border`],
+              colorTokens.neutral[`${variant}HoverColor`],
+              colorTokens.neutral[`${variant}HoverBg`],
+              colorTokens.neutral[`${variant}ActiveColor`],
+              colorTokens.neutral[`${variant}ActiveBg`],
+            ]),
+            '[&:not(:has(:checked))]:',
+          ),
+          addPrefix(
+            join([
+              textColor(baseTokens.neutral[`${variant}DisabledColor`]),
+              backgroundColor(baseTokens.neutral[`${variant}DisabledBg`]),
+              borderColor(baseTokens.neutral[`${variant}DisabledBorder`]),
+            ]),
+            '[&:not(:has(:checked))]:has-[:disabled]:',
+          ),
+        ],
+      ],
+    ]),
+  );
+};
+
+const radioActionVariants = (
+  props?: BaseVariants & {
+    disableIcon?: boolean;
+    overlay?: boolean;
+  },
+) => {
+  const {
+    color,
+    variant = 'outlined',
+    disableIcon = false,
+    overlay = false,
+  } = props ?? {};
+
+  return twMerge(
+    clsx([
+      'tj-radio-action',
+      'absolute',
+      'text-left',
+      overlay
+        ? r`rounded-[var(--Radio-actionRadius,var(--unstable\_actionRadius,inherit))]`
+        : 'rounded-[var(--Radio-actionRadius,inherit)]',
+      'inset-[calc(-1*var(--variant-borderWidth,0px))]',
+      'z-[1]',
+      addPrefix(
+        join([
+          'outline-2 outline outline-offset-2',
+          toColorClass(baseTokens.focusVisible, 'outline-'),
+        ]),
+        'has-[:focus-visible]:',
+      ),
+      disableIcon && [
+        variant === 'outlined'
+          ? '[--variant-borderWidth:1px] [border-width:var(--variant-borderWidth)] border-solid'
+          : '[--variant-borderWidth:0px]',
+        addPrefix(
+          'pointer-events-none cursor-default [--Icon-color:currentColor]',
+          'has-[:disabled]:',
+        ),
+        color && [
+          colorTokens[color][`${variant}Color`],
+          colorTokens[color][`${variant}Bg`],
+          colorTokens[color][`${variant}Border`],
+          colorTokens[color][`${variant}HoverColor`],
+          colorTokens[color][`${variant}HoverBg`],
+          colorTokens[color][`${variant}ActiveColor`],
+          colorTokens[color][`${variant}ActiveBg`],
+          addPrefix(
+            join([
+              textColor(baseTokens[color][`${variant}DisabledColor`]),
+              backgroundColor(baseTokens[color][`${variant}DisabledBg`]),
+              borderColor(baseTokens[color][`${variant}DisabledBorder`]),
+            ]),
+            'has-[:disabled]:',
+          ),
+        ],
+        !color && [
+          addPrefix(
+            join([
+              colorTokens.primary[`${variant}Color`],
+              colorTokens.primary[`${variant}Bg`],
+              colorTokens.primary[`${variant}Border`],
+              colorTokens.primary[`${variant}HoverColor`],
+              colorTokens.primary[`${variant}HoverBg`],
+              colorTokens.primary[`${variant}ActiveColor`],
+              colorTokens.primary[`${variant}ActiveBg`],
+            ]),
+            'has-[:checked]:',
+          ),
+          addPrefix(
+            join([
+              textColor(baseTokens.primary[`${variant}DisabledColor`]),
+              backgroundColor(baseTokens.primary[`${variant}DisabledBg`]),
+              borderColor(baseTokens.primary[`${variant}DisabledBorder`]),
+            ]),
+            'has-[:checked]:has-[:disabled]:',
+          ),
+          addPrefix(
+            join([
+              colorTokens.neutral[`${variant}Color`],
+              colorTokens.neutral[`${variant}Bg`],
+              colorTokens.neutral[`${variant}Border`],
+              colorTokens.neutral[`${variant}HoverColor`],
+              colorTokens.neutral[`${variant}HoverBg`],
+              colorTokens.neutral[`${variant}ActiveColor`],
+              colorTokens.neutral[`${variant}ActiveBg`],
+            ]),
+            '[&:not(:has(:checked))]:',
+          ),
+          addPrefix(
+            join([
+              textColor(baseTokens.neutral[`${variant}DisabledColor`]),
+              backgroundColor(baseTokens.neutral[`${variant}DisabledBg`]),
+              borderColor(baseTokens.neutral[`${variant}DisabledBorder`]),
+            ]),
+            '[&:not(:has(:checked))]:has-[:disabled]:',
+          ),
+        ],
+      ],
+    ]),
+  );
+};
+
+const radioInputVariants = (props?: BaseVariants) => {
+  return twMerge(
+    clsx([
+      'tj-radio-input',
+      'm-0',
+      'opacity-0',
+      'absolute',
+      'h-full',
+      'w-full',
+      'cursor-pointer',
+    ]),
+  );
+};
+
+const radioLabelVariants = (
+  props?: BaseVariants & {
+    disableIcon?: boolean;
+  },
+) => {
+  const { disableIcon = false } = props ?? {};
+
+  return twMerge(
+    clsx([
+      'tj-radio-label',
+      'flex-1',
+      'min-w-0',
+      disableIcon && ['z-[1]', 'pointer-events-none'],
+    ]),
+  );
+};
+
+const radioIconVariants = (props?: BaseVariants) => {
+  return twMerge(
+    clsx([
+      'tj-radio-icon',
+      'w-[calc(var(--Radio-size)/2)]',
+      'h-[calc(var(--Radio-size)/2)]',
+      'rounded-[inherit]',
+      'text-inherit',
+      'bg-current',
+      'group-has-[:checked]/tj-radio:scale-100',
+      r`[.group\/tj-radio:not(:has(:checked))_&]:scale-0`,
+    ]),
+  );
+};
+
+interface RadioRootVariants extends BaseVariants {
+  disableIcon?: boolean;
+  label?: ReactNode;
+  overlay?: boolean;
+}
 
 type RadioRootProps = Omit<ComponentProps<'input'>, keyof RadioRootVariants> &
   RadioRootVariants;
 
 export const Radio = forwardRef<HTMLSpanElement, RadioRootProps>(
   function RadioRoot(
-    { children, className, color, size, variant, ...otherProps },
+    {
+      children,
+      className,
+      id,
+      color,
+      size,
+      variant,
+      checked,
+      defaultChecked,
+      disabled,
+      disableIcon,
+      label,
+      overlay,
+      ...otherProps
+    },
     ref,
   ) {
+    const [instanceId, setInstanceId] = useState(id ?? uuid());
+
     return (
       <span
         ref={ref}
-        className={twMerge(radioRootVariants(), className)}
-        {...otherProps}
+        className={twMerge(
+          radioRootVariants({
+            color,
+            size,
+            variant,
+            disableIcon,
+            overlay,
+          }),
+          className,
+        )}
       >
-        {children}
+        <span
+          className={radioRadioVariants({
+            color,
+            variant,
+            disableIcon,
+          })}
+        >
+          {disableIcon ? null : <span className={radioIconVariants()} />}
+          <span
+            className={radioActionVariants({
+              color,
+              variant,
+              disableIcon,
+              overlay,
+            })}
+          >
+            <input
+              id={instanceId}
+              type="radio"
+              className={radioInputVariants()}
+              checked={checked}
+              defaultChecked={defaultChecked}
+              disabled={disabled}
+              {...otherProps}
+            />
+          </span>
+        </span>
+        {label && (
+          <label
+            htmlFor={instanceId}
+            className={radioLabelVariants({ disableIcon })}
+          >
+            {label}
+          </label>
+        )}
       </span>
     );
   },
@@ -63,6 +449,43 @@ export const Radio = forwardRef<HTMLSpanElement, RadioRootProps>(
 export const generatorInputs: GeneratorInput[] = [
   {
     generatorFn: radioRootVariants,
+    variants: {
+      color: [undefined, 'primary', 'neutral', 'danger', 'success', 'warning'],
+      size: ['sm', 'md', 'lg'],
+      variant: ['solid', 'soft', 'outlined', 'plain'],
+      disableIcon: [false, true],
+      overlay: [false, true],
+    },
+  },
+  {
+    generatorFn: radioRadioVariants,
+    variants: {
+      color: [undefined, 'primary', 'neutral', 'danger', 'success', 'warning'],
+      variant: ['solid', 'soft', 'outlined', 'plain'],
+      disableIcon: [false, true],
+    },
+  },
+  {
+    generatorFn: radioActionVariants,
+    variants: {
+      color: [undefined, 'primary', 'neutral', 'danger', 'success', 'warning'],
+      variant: ['solid', 'soft', 'outlined', 'plain'],
+      disableIcon: [false, true],
+      overlay: [false, true],
+    },
+  },
+  {
+    generatorFn: radioInputVariants,
+    variants: {},
+  },
+  {
+    generatorFn: radioLabelVariants,
+    variants: {
+      disableIcon: [false, true],
+    },
+  },
+  {
+    generatorFn: radioIconVariants,
     variants: {},
   },
 ];

--- a/packages/tailwind-joy/src/plugins/safelist-generator.ts
+++ b/packages/tailwind-joy/src/plugins/safelist-generator.ts
@@ -6,6 +6,7 @@ import { generatorInputs as circularProgressClassNameGeneratorInputs } from '../
 import { generatorInputs as iconAdapterClassNameGeneratorInputs } from '../components/IconAdapter';
 import { generatorInputs as iconButtonClassNameGeneratorInputs } from '../components/IconButton';
 import { generatorInputs as linearProgressClassNameGeneratorInputs } from '../components/LinearProgress';
+import { generatorInputs as radioClassNameGeneratorInputs } from '../components/Radio';
 
 const SPACE = ' ';
 
@@ -17,6 +18,7 @@ const inputs: GeneratorInput[] = [
   ...iconAdapterClassNameGeneratorInputs,
   ...iconButtonClassNameGeneratorInputs,
   ...linearProgressClassNameGeneratorInputs,
+  ...radioClassNameGeneratorInputs,
 ];
 
 function generate() {


### PR DESCRIPTION
## Summary

This PR adds a radio component to the Tailwind-Joy package.

Because this component uses the [`:has()` variant](https://tailwindcss.com/blog/tailwindcss-v3-4#new-has-variant), it is recommended that you upgrade to Tailwind CSS version 3.4 or higher.