### PR TITLE
feat(core): Implements a box component

### DIFF
--- a/apps/tester/tests/13-box.spec.tsx
+++ b/apps/tester/tests/13-box.spec.tsx
@@ -1,0 +1,127 @@
+import { Box as JoyBox } from '@mui/joy';
+import { Box as TJBox } from 'tailwind-joy/components';
+
+import type { Fixture } from '@/settings';
+import { testEach } from '@/settings';
+
+const containerClassName =
+  'flex h-[100px] w-[100px] items-center justify-center p-2';
+
+const fixtures: Fixture[] = [
+  {
+    title: 'basics',
+    alterSizes: ['md'],
+    alterVariants: ['solid'],
+    alterColors: ['primary'],
+    renderJoyElement({ testId, size, variant, color }) {
+      return (
+        <JoyBox data-testid={testId} sx={{ p: 2, border: '1px dashed grey' }}>
+          Lorem ipsum
+        </JoyBox>
+      );
+    },
+    renderTjElement({ testId, size, variant, color }) {
+      return (
+        <TJBox
+          data-testid={testId}
+          className="border border-dashed border-[grey] p-4"
+        >
+          Lorem ipsum
+        </TJBox>
+      );
+    },
+  },
+  {
+    title: 'component: section',
+    alterSizes: ['md'],
+    alterVariants: ['solid'],
+    alterColors: ['primary'],
+    renderJoyElement({ testId, size, variant, color }) {
+      return (
+        <JoyBox
+          data-testid={testId}
+          sx={{ p: 2, border: '1px dashed grey' }}
+          component="section"
+        >
+          Lorem ipsum
+        </JoyBox>
+      );
+    },
+    renderTjElement({ testId, size, variant, color }) {
+      return (
+        <TJBox
+          data-testid={testId}
+          className="border border-dashed border-[grey] p-4"
+          component="section"
+        >
+          Lorem ipsum
+        </TJBox>
+      );
+    },
+  },
+  {
+    title: 'component: button',
+    alterSizes: ['md'],
+    alterVariants: ['solid'],
+    alterColors: ['primary'],
+    renderJoyElement({ testId, size, variant, color }) {
+      return (
+        <JoyBox
+          data-testid={testId}
+          sx={{ p: 2, border: '1px dashed grey' }}
+          component="button"
+          type="button"
+        >
+          Lorem ipsum
+        </JoyBox>
+      );
+    },
+    renderTjElement({ testId, size, variant, color }) {
+      return (
+        <TJBox
+          data-testid={testId}
+          className="border border-dashed border-[grey] p-4"
+          component="button"
+          type="button"
+        >
+          Lorem ipsum
+        </TJBox>
+      );
+    },
+  },
+  {
+    title: 'component: a',
+    alterSizes: ['md'],
+    alterVariants: ['solid'],
+    alterColors: ['primary'],
+    renderJoyElement({ testId, size, variant, color }) {
+      return (
+        <JoyBox
+          data-testid={testId}
+          sx={{ p: 2, border: '1px dashed grey' }}
+          component="a"
+          href="https://tailwind-joy.vercel.app/"
+        >
+          Lorem ipsum
+        </JoyBox>
+      );
+    },
+    renderTjElement({ testId, size, variant, color }) {
+      return (
+        <TJBox
+          data-testid={testId}
+          className="border border-dashed border-[grey] p-4"
+          component="a"
+          href="https://tailwind-joy.vercel.app/"
+        >
+          Lorem ipsum
+        </TJBox>
+      );
+    },
+  },
+];
+
+testEach(fixtures, {
+  containerClassName,
+  viewport: { width: 500, height: 500 },
+});

--- a/apps/website/docs/apis/13-box.md
+++ b/apps/website/docs/apis/13-box.md
@@ -40,7 +40,6 @@ Other props are as follows:
 ### `component`
 
 The component used for the root node.
-Either a string to use a HTML element or a component.
 
-- Type: `string | FunctionComponent | ComponentClass`
+- Type: `keyof JSX.IntrinsicElements`
 - Default: `'div'`

--- a/apps/website/docs/apis/13-box.md
+++ b/apps/website/docs/apis/13-box.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 13
+title: <Box />
+---
+
+# Box API
+
+<AvailableFrom version="0.4.0" />
+
+API reference docs for the React Box component.
+Learn about the props of this exported module.
+
+## Demos
+
+:::tip
+
+For examples and details on the usage of this React component, visit the component demo pages:
+
+- [Box](../components/box)
+
+:::
+
+## Import
+
+```jsx
+import { Box } from 'tailwind-joy/components';
+```
+
+## Props
+
+:::info
+
+The `ref` is forwarded to the root element.
+
+:::
+
+By default, props available for HTML `<div>` are also available for Box component.
+Other props are as follows:
+
+### `component`
+
+The component used for the root node.
+Either a string to use a HTML element or a component.
+
+- Type: `string | FunctionComponent | ComponentClass`
+- Default: `'div'`

--- a/apps/website/docs/components/06-layout/01-box.mdx
+++ b/apps/website/docs/components/06-layout/01-box.mdx
@@ -3,8 +3,6 @@ sidebar_position: 1
 slug: /components/box
 ---
 
-import { Box as JoyBox } from '@mui/joy';
-
 # Box
 
 <AvailableFrom version="0.4.0" />
@@ -23,12 +21,12 @@ The demo below replaces the `<div>` with a `<section>` element:
 export function BoxBasics() {
   return (
     <DisplayStand>
-      <JoyBox
+      <Box
         component="section"
         className="border border-dashed border-[grey] p-4"
       >
         This Box renders as an HTML section element.
-      </JoyBox>
+      </Box>
     </DisplayStand>
   );
 }

--- a/apps/website/docs/components/06-layout/01-box.mdx
+++ b/apps/website/docs/components/06-layout/01-box.mdx
@@ -9,7 +9,7 @@ import { Box as JoyBox } from '@mui/joy';
 
 <AvailableFrom version="0.4.0" />
 
-The Box component is a generic, theme-aware container.
+The Box component is a generic container.
 
 ## Basics
 

--- a/apps/website/docs/components/06-layout/01-box.mdx
+++ b/apps/website/docs/components/06-layout/01-box.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+slug: /components/box
+---
+
+import { Box as JoyBox } from '@mui/joy';
+
+# Box
+
+<AvailableFrom version="0.4.0" />
+
+The Box component is a generic, theme-aware container.
+
+## Basics
+
+```jsx
+import { Box } from 'tailwind-joy/components';
+```
+
+The Box component renders as a `<div>` by default, but you can swap in any other valid HTML tag or React component using the `component` prop.
+The demo below replaces the `<div>` with a `<section>` element:
+
+export function BoxBasics() {
+  return (
+    <DisplayStand>
+      <JoyBox
+        component="section"
+        className="border border-dashed border-[grey] p-4"
+      >
+        This Box renders as an HTML section element.
+      </JoyBox>
+    </DisplayStand>
+  );
+}
+
+<BoxBasics />
+
+```jsx
+import { Box } from 'tailwind-joy/components';
+
+export function BoxBasics() {
+  return (
+    <Box component="section" className="border border-dashed border-[grey] p-4">
+      This Box renders as an HTML section element.
+    </Box>
+  );
+}
+```
+
+## Anatomy
+
+The Box component is composed of a single root `<div>` element:
+
+```html
+<div class="tj-box-root ...">
+  <!-- Box contents -->
+</div>
+```
+
+## API
+
+See the documentation below for a complete reference to all of the props available to the components mentioned here.
+
+- [`<Box />`](../apis/box)

--- a/apps/website/docs/components/06-layout/_category_.json
+++ b/apps/website/docs/components/06-layout/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Layout",
+  "position": 6
+}

--- a/apps/website/src/theme/MDXComponents.js
+++ b/apps/website/src/theme/MDXComponents.js
@@ -2,6 +2,7 @@ import MDXComponents from '@theme-original/MDXComponents';
 import { CssVarsProvider } from '@mui/joy/styles';
 import { Button as JoyButton } from '@mui/joy';
 import {
+  Box,
   Button,
   ButtonGroup,
   Checkbox,
@@ -29,6 +30,7 @@ export default {
 
   // --------------------------------
 
+  Box,
   Button,
   ButtonGroup,
   Checkbox,

--- a/packages/tailwind-joy/README.md
+++ b/packages/tailwind-joy/README.md
@@ -31,6 +31,10 @@ https://tailwind-joy.vercel.app
 
 - Sheet
 
+### Layout
+
+- Box
+
 ### Tailwind-Joy's original
 
 - Icon Adapter

--- a/packages/tailwind-joy/src/base/types.ts
+++ b/packages/tailwind-joy/src/base/types.ts
@@ -1,3 +1,87 @@
+import type { ComponentProps, ReactHTML } from 'react';
+
+type ElementNamesThatHaveTheirOwnProps =
+  | 'a'
+  | 'area'
+  | 'audio'
+  | 'base'
+  | 'blockquote'
+  | 'button'
+  | 'canvas'
+  | 'col'
+  | 'colgroup'
+  | 'data'
+  | 'del'
+  | 'details'
+  | 'dialog'
+  | 'embed'
+  | 'fieldset'
+  | 'form'
+  | 'html'
+  | 'iframe'
+  | 'img'
+  | 'input'
+  | 'ins'
+  | 'keygen'
+  | 'label'
+  | 'li'
+  | 'link'
+  | 'map'
+  | 'menu'
+  | 'meta'
+  | 'meter'
+  | 'object'
+  | 'ol'
+  | 'optgroup'
+  | 'option'
+  | 'output'
+  | 'param'
+  | 'progress'
+  | 'q'
+  | 'slot'
+  | 'script'
+  | 'select'
+  | 'source'
+  | 'style'
+  | 'table'
+  | 'td'
+  | 'textarea'
+  | 'th'
+  | 'time'
+  | 'track'
+  | 'video'
+  | 'webview';
+
+export type ComponentPropsWithVariants<
+  T extends keyof JSX.IntrinsicElements,
+  V extends {},
+> = Omit<ComponentProps<T>, keyof V> & V;
+
+type NamedComponentPropsWithVariants<
+  T extends keyof ReactHTML,
+  V extends {},
+> = {
+  component: T;
+} & ComponentPropsWithVariants<T, V>;
+
+type DistributeWithVariants<
+  T extends ElementNamesThatHaveTheirOwnProps,
+  V extends {},
+> = T extends unknown ? NamedComponentPropsWithVariants<T, V> : never;
+
+export type GenericComponentPropsWithVariants<
+  T extends keyof JSX.IntrinsicElements,
+  V extends {},
+> =
+  | ({ component?: never } & ComponentPropsWithVariants<T, V>)
+  | DistributeWithVariants<ElementNamesThatHaveTheirOwnProps, V>
+  | ({
+      component?: Exclude<
+        keyof JSX.IntrinsicElements,
+        ElementNamesThatHaveTheirOwnProps
+      >;
+    } & ComponentPropsWithVariants<'div', V>);
+
 export type BaseVariants = {
   color?: 'primary' | 'neutral' | 'danger' | 'success' | 'warning';
   size?: 'sm' | 'md' | 'lg';

--- a/packages/tailwind-joy/src/components.ts
+++ b/packages/tailwind-joy/src/components.ts
@@ -1,3 +1,4 @@
+export { Box } from './components/Box';
 export { Button } from './components/Button';
 export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';

--- a/packages/tailwind-joy/src/components/Box.tsx
+++ b/packages/tailwind-joy/src/components/Box.tsx
@@ -1,38 +1,33 @@
 import { clsx } from 'clsx';
-import type { ComponentProps, FunctionComponent, ComponentClass } from 'react';
 import { forwardRef, createElement } from 'react';
 import { twMerge } from 'tailwind-merge';
-import type { BaseVariants, GeneratorInput } from '@/base/types';
+import type {
+  BaseVariants,
+  GeneratorInput,
+  GenericComponentPropsWithVariants,
+} from '@/base/types';
 
 function boxRootVariants(props?: BaseVariants) {
   return twMerge(clsx(['tj-box-root group/tj-box']));
 }
 
-interface BoxRootVariants {
-  component?: string | FunctionComponent | ComponentClass;
-}
+interface BoxRootVariants {}
 
-type BoxRootProps = Omit<ComponentProps<'div'>, keyof BoxRootVariants> &
-  BoxRootVariants;
+type BoxRootProps = GenericComponentPropsWithVariants<'div', BoxRootVariants>;
 
-export const Box = forwardRef<HTMLElement, BoxRootProps>(function BoxRoot(
-  { children, className, component = 'div', ...otherProps },
+export const Box = forwardRef(function BoxRoot(
+  { children, className, component = 'div', ...otherProps }: BoxRootProps,
   ref,
 ) {
-  return typeof component === 'string'
-    ? createElement(
-        component,
-        {
-          ref,
-          className: twMerge(boxRootVariants(), className),
-          ...otherProps,
-        },
-        children,
-      )
-    : createElement(component, {
-        // @ts-expect-error
-        ref,
-      });
+  return createElement(
+    component,
+    {
+      ref,
+      className: twMerge(boxRootVariants(), className),
+      ...otherProps,
+    },
+    children,
+  );
 });
 
 export const generatorInputs: GeneratorInput[] = [

--- a/packages/tailwind-joy/src/components/Box.tsx
+++ b/packages/tailwind-joy/src/components/Box.tsx
@@ -1,0 +1,43 @@
+import { clsx } from 'clsx';
+import type { ComponentProps, FunctionComponent, ComponentClass } from 'react';
+import { forwardRef, createElement } from 'react';
+import { twMerge } from 'tailwind-merge';
+import type { BaseVariants, GeneratorInput } from '@/base/types';
+
+function boxRootVariants(props?: BaseVariants) {
+  return twMerge(clsx(['tj-box-root group/tj-box']));
+}
+
+interface BoxRootVariants {
+  component?: string | FunctionComponent | ComponentClass;
+}
+
+type BoxRootProps = Omit<ComponentProps<'div'>, keyof BoxRootVariants> &
+  BoxRootVariants;
+
+export const Box = forwardRef<HTMLElement, BoxRootProps>(function BoxRoot(
+  { children, className, component = 'div', ...otherProps },
+  ref,
+) {
+  return typeof component === 'string'
+    ? createElement(
+        component,
+        {
+          ref,
+          className: twMerge(boxRootVariants(), className),
+          ...otherProps,
+        },
+        children,
+      )
+    : createElement(component, {
+        // @ts-expect-error
+        ref,
+      });
+});
+
+export const generatorInputs: GeneratorInput[] = [
+  {
+    generatorFn: boxRootVariants,
+    variants: {},
+  },
+];

--- a/packages/tailwind-joy/src/plugins/safelist-generator.ts
+++ b/packages/tailwind-joy/src/plugins/safelist-generator.ts
@@ -1,4 +1,5 @@
 import type { GeneratorInput } from '../base/types';
+import { generatorInputs as boxClassNameGeneratorInputs } from '../components/Box';
 import { generatorInputs as buttonClassNameGeneratorInputs } from '../components/Button';
 import { generatorInputs as buttonGroupClassNameGeneratorInputs } from '../components/ButtonGroup';
 import { generatorInputs as checkboxClassNameGeneratorInputs } from '../components/Checkbox';
@@ -16,6 +17,7 @@ import { generatorInputs as adaptedIconClassNameGeneratorInputs } from '../compo
 const SPACE = ' ';
 
 const inputs: GeneratorInput[] = [
+  ...boxClassNameGeneratorInputs,
   ...buttonClassNameGeneratorInputs,
   ...buttonGroupClassNameGeneratorInputs,
   ...checkboxClassNameGeneratorInputs,


### PR DESCRIPTION
## Summary

This PR adds a box component to the Tailwind-Joy package.

This component is the first to implement the `component` property. :sparkles: