### PR TITLE
fix(core): Removes the native outline of the input component

### DIFF
--- a/apps/tester/src/settings.tsx
+++ b/apps/tester/src/settings.tsx
@@ -52,7 +52,10 @@ export function testEach(
 ) {
   const { containerClassName, viewport } = options;
 
-  test.use({ viewport });
+  test.use({
+    viewport,
+    deviceScaleFactor: 1,
+  });
 
   for (const {
     title,

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -84,7 +84,7 @@ function inputInputVariants(props?: {
       'tj-input-input',
       'border-none',
       'min-w-0',
-      'outline-0',
+      'outline-none',
       'p-0',
       'flex-1',
       '[color:inherit]',


### PR DESCRIPTION
## Summary

I found an issue in Safari browser where the outline was not completely removed with just the `outline-0` class name, so I fixed it.