### PR TITLE
feat(core): Prevents `leading-*` class names from being merged with `text-*` class names

### DIFF
--- a/packages/tailwind-joy/src/base/alias.ts
+++ b/packages/tailwind-joy/src/base/alias.ts
@@ -1,3 +1,4 @@
+import { extendTailwindMerge } from 'tailwind-merge';
 import { v4 } from 'uuid';
 
 export const r = String.raw;
@@ -11,3 +12,11 @@ export function uuid() {
     rng: naiveRng,
   });
 }
+
+export const twMerge = extendTailwindMerge({
+  override: {
+    conflictingClassGroups: {
+      'font-size': [],
+    },
+  },
+});

--- a/packages/tailwind-joy/src/base/theme.ts
+++ b/packages/tailwind-joy/src/base/theme.ts
@@ -1086,7 +1086,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-xl,700)]',
         'text-[length:var(--joy-fontSize-xl4,2.25rem)]',
-        '[line-height:var(--joy-lineHeight-xs,1.33334)]',
+        'leading-[var(--joy-lineHeight-xs,1.33334)]',
         'tracking-[-0.025em]',
         colorTokens.text.primary,
       ],
@@ -1104,7 +1104,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-xl,700)]',
         'text-[length:var(--joy-fontSize-xl3,1.875rem)]',
-        '[line-height:var(--joy-lineHeight-xs,1.33334)]',
+        'leading-[var(--joy-lineHeight-xs,1.33334)]',
         'tracking-[-0.025em]',
         colorTokens.text.primary,
       ],
@@ -1122,7 +1122,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-lg,600)]',
         'text-[length:var(--joy-fontSize-xl2,1.5rem)]',
-        '[line-height:var(--joy-lineHeight-xs,1.33334)]',
+        'leading-[var(--joy-lineHeight-xs,1.33334)]',
         'tracking-[-0.025em]',
         colorTokens.text.primary,
       ],
@@ -1140,7 +1140,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-lg,600)]',
         'text-[length:var(--joy-fontSize-xl,1.25rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         'tracking-[-0.025em]',
         colorTokens.text.primary,
       ],
@@ -1158,7 +1158,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-lg,600)]',
         'text-[length:var(--joy-fontSize-lg,1.125rem)]',
-        '[line-height:var(--joy-lineHeight-xs,1.33334)]',
+        'leading-[var(--joy-lineHeight-xs,1.33334)]',
         colorTokens.text.primary,
       ],
       values: {
@@ -1175,7 +1175,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-md,500)]',
         'text-[length:var(--joy-fontSize-md,1rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         colorTokens.text.primary,
       ],
       values: {
@@ -1192,7 +1192,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-md,500)]',
         'text-[length:var(--joy-fontSize-sm,0.875rem)]',
-        '[line-height:var(--joy-lineHeight-sm,1.42858)]',
+        'leading-[var(--joy-lineHeight-sm,1.42858)]',
         colorTokens.text.primary,
       ],
       values: {
@@ -1208,7 +1208,7 @@ export const theme = {
     'body-lg': {
       className: [
         'text-[length:var(--joy-fontSize-lg,1.125rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         colorTokens.text.secondary,
       ],
       values: {
@@ -1224,7 +1224,7 @@ export const theme = {
     'body-md': {
       className: [
         'text-[length:var(--joy-fontSize-md,1rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         colorTokens.text.secondary,
       ],
       values: {
@@ -1240,7 +1240,7 @@ export const theme = {
     'body-sm': {
       className: [
         'text-[length:var(--joy-fontSize-sm,0.875rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         colorTokens.text.tertiary,
       ],
       values: {
@@ -1257,7 +1257,7 @@ export const theme = {
       className: [
         'font-[var(--joy-fontWeight-md,500)]',
         'text-[length:var(--joy-fontSize-xs,0.75rem)]',
-        '[line-height:var(--joy-lineHeight-md,1.5)]',
+        'leading-[var(--joy-lineHeight-md,1.5)]',
         colorTokens.text.tertiary,
       ],
       values: {

--- a/packages/tailwind-joy/src/components/Box.tsx
+++ b/packages/tailwind-joy/src/components/Box.tsx
@@ -1,11 +1,11 @@
 import { clsx } from 'clsx';
 import type { ForwardedRef } from 'react';
 import { forwardRef, createElement } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
+import { twMerge } from '../base/alias';
 
 function boxRootVariants() {
   return twMerge(clsx(['tj-box-root group/tj-box']));

--- a/packages/tailwind-joy/src/components/Button.tsx
+++ b/packages/tailwind-joy/src/components/Button.tsx
@@ -1,12 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
+import { twMerge } from '../base/alias';
 import {
   hover,
   focus,

--- a/packages/tailwind-joy/src/components/ButtonGroup.tsx
+++ b/packages/tailwind-joy/src/components/ButtonGroup.tsx
@@ -8,13 +8,12 @@ import {
   Children,
   useMemo,
 } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r } from '../base/alias';
+import { r, twMerge } from '../base/alias';
 import { addPrefix, toVariableClass } from '../base/modifier';
 import { theme } from '../base/theme';
 import { excludeClassName } from '../base/utils';

--- a/packages/tailwind-joy/src/components/Checkbox.tsx
+++ b/packages/tailwind-joy/src/components/Checkbox.tsx
@@ -2,13 +2,12 @@ import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useState, useMemo } from 'react';
 import { MdCheck, MdHorizontalRule } from 'react-icons/md';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r, uuid } from '../base/alias';
+import { r, uuid, twMerge } from '../base/alias';
 import {
   addPrefix,
   toColorClass,

--- a/packages/tailwind-joy/src/components/CircularProgress.tsx
+++ b/packages/tailwind-joy/src/components/CircularProgress.tsx
@@ -1,13 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r } from '../base/alias';
+import { r, twMerge } from '../base/alias';
 import {
   addPrefix,
   borderColor,

--- a/packages/tailwind-joy/src/components/Divider.tsx
+++ b/packages/tailwind-joy/src/components/Divider.tsx
@@ -1,12 +1,11 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r } from '../base/alias';
+import { r, twMerge } from '../base/alias';
 import { addPrefix } from '../base/modifier';
 import { colorTokens } from '../base/tokens';
 import { excludeClassName } from '../base/utils';

--- a/packages/tailwind-joy/src/components/IconButton.tsx
+++ b/packages/tailwind-joy/src/components/IconButton.tsx
@@ -1,12 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
+import { twMerge } from '../base/alias';
 import {
   hover,
   focus,

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -1,13 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r } from '../base/alias';
+import { r, twMerge } from '../base/alias';
 import {
   addPrefix,
   backgroundColor,

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -90,7 +90,7 @@ function inputInputVariants(props?: {
       '[color:inherit]',
       'bg-transparent',
       '[font-family:inherit]',
-      '[font-size:inherit]',
+      'text-[length:inherit]',
       '[font-style:inherit]',
       '[font-weight:inherit]',
       'leading-[inherit]',

--- a/packages/tailwind-joy/src/components/LinearProgress.tsx
+++ b/packages/tailwind-joy/src/components/LinearProgress.tsx
@@ -1,13 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r } from '../base/alias';
+import { r, twMerge } from '../base/alias';
 import { addPrefix, backgroundColor, textColor } from '../base/modifier';
 import { theme } from '../base/theme';
 import { excludeClassName } from '../base/utils';

--- a/packages/tailwind-joy/src/components/Radio.tsx
+++ b/packages/tailwind-joy/src/components/Radio.tsx
@@ -7,13 +7,12 @@ import {
   useState,
   useMemo,
 } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r, uuid } from '../base/alias';
+import { r, uuid, twMerge } from '../base/alias';
 import {
   addPrefix,
   toColorClass,

--- a/packages/tailwind-joy/src/components/RadioGroup.tsx
+++ b/packages/tailwind-joy/src/components/RadioGroup.tsx
@@ -7,13 +7,12 @@ import {
   useState,
   useMemo,
 } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r, uuid } from '../base/alias';
+import { r, uuid, twMerge } from '../base/alias';
 import { theme } from '../base/theme';
 import { excludeClassName } from '../base/utils';
 

--- a/packages/tailwind-joy/src/components/Sheet.tsx
+++ b/packages/tailwind-joy/src/components/Sheet.tsx
@@ -1,12 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
+import { twMerge } from '../base/alias';
 import { toVariableClass } from '../base/modifier';
 import { theme } from '../base/theme';
 import { baseTokens, colorTokens } from '../base/tokens';

--- a/packages/tailwind-joy/src/components/Switch.tsx
+++ b/packages/tailwind-joy/src/components/Switch.tsx
@@ -1,13 +1,12 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useState, useMemo } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
-import { r, uuid } from '../base/alias';
+import { r, uuid, twMerge } from '../base/alias';
 import {
   addPrefix,
   hover,

--- a/packages/tailwind-joy/src/components/Typography.tsx
+++ b/packages/tailwind-joy/src/components/Typography.tsx
@@ -8,12 +8,12 @@ import {
   useContext,
   useMemo,
 } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type {
   BaseVariants,
   GeneratorInput,
   GenericComponentPropsWithVariants,
 } from '@/base/types';
+import { twMerge } from '../base/alias';
 import { theme } from '../base/theme';
 import { baseTokens } from '../base/tokens';
 import { excludeClassName } from '../base/utils';

--- a/packages/tailwind-joy/src/components/internal/class-adapter.ts
+++ b/packages/tailwind-joy/src/components/internal/class-adapter.ts
@@ -33,9 +33,9 @@ export function iconClassVariants(
       'h-[1em]',
       'inline-block',
       'shrink-0',
-      size === 'sm' && '[font-size:var(--Icon-fontSize,1.25rem)]',
-      size === 'md' && '[font-size:var(--Icon-fontSize,1.5rem)]',
-      size === 'lg' && '[font-size:var(--Icon-fontSize,1.875rem)]',
+      size === 'sm' && 'text-[length:var(--Icon-fontSize,1.25rem)]',
+      size === 'md' && 'text-[length:var(--Icon-fontSize,1.5rem)]',
+      size === 'lg' && 'text-[length:var(--Icon-fontSize,1.875rem)]',
       baseTokens[color].mainChannel.replace(
         /(joy-[a-z0-9]+-[a-z0-9]+)/g,
         '[color:var(--Icon-color,var(--$1))]',

--- a/packages/tailwind-joy/src/components/internal/class-adapter.ts
+++ b/packages/tailwind-joy/src/components/internal/class-adapter.ts
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx';
 import type { ReactNode } from 'react';
 import { cloneElement, isValidElement } from 'react';
-import { twMerge } from 'tailwind-merge';
 import type { BaseVariants, GeneratorInput } from '@/base/types';
+import { twMerge } from '../../base/alias';
 import { baseTokens } from '../../base/tokens';
 
 export function adaptClassName(node: ReactNode, className: string): ReactNode {


### PR DESCRIPTION
## Summary

This PR [extends the config of `tailwind-merge`](https://github.com/dcastil/tailwind-merge/blob/v2.3.0/docs/api-reference.md#extendtailwindmerge) to prevent `leading-*` class names from being merged by `text-*` class names provided outside the component.

For example, if you write
```jsx
<Typography className="text-[1.25rem]">Lorem ipsum</Typography>
```
, the `leading-*` class names written inside `Typography` will be preserved.

This also applies to the default `text-*` class names in Tailwind CSS, so if you want to change the `line-height` as well, you should write it like
```jsx
<Typography className="text-xl leading-7">Lorem ipsum</Typography>
```
instead of
```jsx
<Typography className="text-xl">Lorem ipsum</Typography>
```
.