### PR TITLE
fix(core): Removes the native border of button component and icon button component

### DIFF
--- a/packages/tailwind-joy/src/components/Button.tsx
+++ b/packages/tailwind-joy/src/components/Button.tsx
@@ -122,7 +122,7 @@ function buttonRootVariants(
       'box-border',
       'rounded-[var(--Button-radius,6px)]',
       'm-[var(--Button-margin)]',
-      'border-none',
+      'border-0',
       'bg-transparent',
       'cursor-pointer',
       'select-none',

--- a/packages/tailwind-joy/src/components/Chip.tsx
+++ b/packages/tailwind-joy/src/components/Chip.tsx
@@ -151,7 +151,7 @@ function chipActionVariants(props?: Pick<BaseVariants, 'color' | 'variant'>) {
       'z-0',
       'inset-0',
       'w-full',
-      'border-none',
+      'border-0',
       'cursor-pointer',
       'p-[initial]',
       'm-[initial]',

--- a/packages/tailwind-joy/src/components/Divider.tsx
+++ b/packages/tailwind-joy/src/components/Divider.tsx
@@ -110,7 +110,7 @@ function dividerRootVariants(props?: {
             ),
           ]
         : [
-            'border-none',
+            'border-0',
             'list-none',
             'bg-[var(--Divider-lineColor)]',
             orientation === 'vertical'

--- a/packages/tailwind-joy/src/components/IconButton.tsx
+++ b/packages/tailwind-joy/src/components/IconButton.tsx
@@ -101,7 +101,7 @@ export function iconButtonRootVariants(
       'font-medium',
       'm-[var(--IconButton-margin)]',
       'rounded-[var(--IconButton-radius,6px)]',
-      'border-none',
+      'border-0',
       'box-border',
       'bg-transparent',
       'cursor-pointer',

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -81,7 +81,7 @@ function inputInputVariants(props?: {
   return twMerge(
     clsx([
       'tj-input-input',
-      'border-none',
+      'border-0',
       'min-w-0',
       'outline-none',
       'p-0',

--- a/packages/tailwind-joy/src/components/Switch.tsx
+++ b/packages/tailwind-joy/src/components/Switch.tsx
@@ -119,7 +119,7 @@ function switchRootVariants(props?: BaseVariants) {
       'relative',
       'p-[calc((var(--Switch-thumbSize)/2)-(var(--Switch-trackHeight)/2))_calc(-1*var(--Switch-thumbOffset))]',
       'bg-[color:initial]',
-      'border-none',
+      'border-0',
       r`m-[var(--unstable\_Switch-margin)]`,
     ]),
   );


### PR DESCRIPTION
## Summary

I found that the class name of the button group component changed by #37 was affecting the style of its child button components and icon button components, so I fixed it.