### PR TITLE
refactor(core): Generate a unique ID using the native method instead of a UUID

### DIFF
--- a/packages/tailwind-joy/commands/makeComponent.mjs
+++ b/packages/tailwind-joy/commands/makeComponent.mjs
@@ -56,7 +56,7 @@ async function main({ name }) {
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useMemo } from 'react';
-import { r, uuid, twMerge } from '../base/alias';
+import { r, twMerge, useUniqueId } from '../base/alias';
 import {
   addPrefix,
   hover,

--- a/packages/tailwind-joy/package.json
+++ b/packages/tailwind-joy/package.json
@@ -50,8 +50,7 @@
   "dependencies": {
     "clsx": "2.1.1",
     "react-icons": "5.2.1",
-    "tailwind-merge": "2.3.0",
-    "uuid": "10.0.0"
+    "tailwind-merge": "2.3.0"
   },
   "devDependencies": {
     "@types/react": "18.2.79",

--- a/packages/tailwind-joy/package.json
+++ b/packages/tailwind-joy/package.json
@@ -54,7 +54,6 @@
   },
   "devDependencies": {
     "@types/react": "18.2.79",
-    "@types/uuid": "10.0.0",
     "@vitejs/plugin-react": "4.3.0",
     "commander": "12.1.0",
     "react": "18.2.0",

--- a/packages/tailwind-joy/src/base/alias.ts
+++ b/packages/tailwind-joy/src/base/alias.ts
@@ -1,17 +1,7 @@
+import { useId } from 'react';
 import { extendTailwindMerge } from 'tailwind-merge';
-import { v4 } from 'uuid';
 
 export const r = String.raw;
-
-function naiveRng() {
-  return [...Array(16)].map(() => Math.floor(Math.random() * 0x100));
-}
-
-export function uuid() {
-  return v4({
-    rng: naiveRng,
-  });
-}
 
 export const twMerge = extendTailwindMerge({
   override: {
@@ -20,3 +10,9 @@ export const twMerge = extendTailwindMerge({
     },
   },
 });
+
+export function useUniqueId() {
+  const id = useId();
+
+  return `tj-${id}`;
+}

--- a/packages/tailwind-joy/src/components/Checkbox.tsx
+++ b/packages/tailwind-joy/src/components/Checkbox.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useState, useMemo } from 'react';
 import { MdCheck, MdHorizontalRule } from 'react-icons/md';
-import { r, uuid, twMerge } from '../base/alias';
+import { r, twMerge, useUniqueId } from '../base/alias';
 import {
   addPrefix,
   toColorClass,
@@ -291,7 +291,7 @@ function CheckboxRoot<T extends ReactTags = 'span'>(
   }: CheckboxRootProps<T>,
   ref: ForwardedRef<unknown>,
 ) {
-  const [instanceId, setInstanceId] = useState(id ?? uuid());
+  const instanceId = useUniqueId();
   const [uncontrolledChecked, setUncontrolledChecked] = useState(
     defaultChecked ?? false,
   );
@@ -365,7 +365,7 @@ function CheckboxRoot<T extends ReactTags = 'span'>(
               checked,
               defaultChecked,
               disabled,
-              id: instanceId,
+              id: id ?? instanceId,
               onBlur,
               onChange: (e) => {
                 if (checked === undefined) {
@@ -406,7 +406,7 @@ function CheckboxRoot<T extends ReactTags = 'span'>(
       </span>
       {label && (
         <label
-          htmlFor={instanceId}
+          htmlFor={id ?? instanceId}
           className={twMerge(
             checkboxLabelVariants({ disableIcon }),
             slotProps.label?.className ?? '',

--- a/packages/tailwind-joy/src/components/Radio.tsx
+++ b/packages/tailwind-joy/src/components/Radio.tsx
@@ -1,13 +1,7 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
-import {
-  forwardRef,
-  createElement,
-  useContext,
-  useState,
-  useMemo,
-} from 'react';
-import { r, uuid, twMerge } from '../base/alias';
+import { forwardRef, createElement, useContext, useMemo } from 'react';
+import { r, twMerge, useUniqueId } from '../base/alias';
 import {
   addPrefix,
   toColorClass,
@@ -481,7 +475,7 @@ function RadioRoot<T extends ReactTags = 'span'>(
   ref: ForwardedRef<unknown>,
 ) {
   const radioGroup = useContext(RadioGroupContext);
-  const [instanceId, setInstanceId] = useState(id ?? uuid());
+  const instanceId = useUniqueId();
   const slotPropsWithoutClassName = useMemo(
     () => excludeClassName(slotProps),
     [slotProps],
@@ -562,7 +556,7 @@ function RadioRoot<T extends ReactTags = 'span'>(
               checked: instanceChecked,
               defaultChecked: instanceDefaultChecked,
               disabled,
-              id: instanceId,
+              id: id ?? instanceId,
               name: instanceName,
               onBlur,
               onChange: instanceOnChange,
@@ -577,7 +571,7 @@ function RadioRoot<T extends ReactTags = 'span'>(
       </span>
       {label && (
         <label
-          htmlFor={instanceId}
+          htmlFor={id ?? instanceId}
           className={twMerge(
             radioLabelVariants({ disableIcon: instanceDisableIcon }),
             slotProps.label?.className ?? '',

--- a/packages/tailwind-joy/src/components/RadioGroup.tsx
+++ b/packages/tailwind-joy/src/components/RadioGroup.tsx
@@ -1,13 +1,7 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef } from 'react';
-import {
-  createContext,
-  forwardRef,
-  createElement,
-  useState,
-  useMemo,
-} from 'react';
-import { r, uuid, twMerge } from '../base/alias';
+import { createContext, forwardRef, createElement, useMemo } from 'react';
+import { r, twMerge, useUniqueId } from '../base/alias';
 import { theme } from '../base/theme';
 import type {
   ReactTags,
@@ -112,7 +106,7 @@ function RadioGroupRoot<T extends ReactTags = 'div'>(
   }: RadioGroupRootProps<T>,
   ref: ForwardedRef<unknown>,
 ) {
-  const [instanceName, setInstanceName] = useState(name ?? uuid());
+  const instanceName = useUniqueId();
   const slotPropsWithoutClassName = useMemo(
     () => excludeClassName(slotProps),
     [slotProps],
@@ -125,7 +119,7 @@ function RadioGroupRoot<T extends ReactTags = 'div'>(
         defaultValue,
         disableIcon,
         overlay,
-        name: instanceName,
+        name: name ?? instanceName,
         value,
         onChange,
       }}

--- a/packages/tailwind-joy/src/components/Switch.tsx
+++ b/packages/tailwind-joy/src/components/Switch.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
 import { forwardRef, createElement, useState, useMemo } from 'react';
-import { r, uuid, twMerge } from '../base/alias';
+import { r, twMerge, useUniqueId } from '../base/alias';
 import {
   addPrefix,
   hover,
@@ -273,7 +273,7 @@ function SwitchRoot<T extends ReactTags = 'div'>(
   }: SwitchRootProps<T>,
   ref: ForwardedRef<unknown>,
 ) {
-  const [instanceId, setInstanceId] = useState(id ?? uuid());
+  const instanceId = useUniqueId();
   const [uncontrolledChecked, setUncontrolledChecked] = useState(
     defaultChecked ?? false,
   );
@@ -350,7 +350,7 @@ function SwitchRoot<T extends ReactTags = 'div'>(
             checked,
             defaultChecked,
             disabled,
-            id: instanceId,
+            id: id ?? instanceId,
             onBlur,
             onChange: (e) => {
               if (checked === undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       '@types/react':
         specifier: 18.2.79
         version: 18.2.79
-      '@types/uuid':
-        specifier: 10.0.0
-        version: 10.0.0
       '@vitejs/plugin-react':
         specifier: 4.3.0
         version: 4.3.0(vite@5.0.11)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       tailwind-merge:
         specifier: 2.3.0
         version: 2.3.0
-      uuid:
-        specifier: 10.0.0
-        version: 10.0.0
     devDependencies:
       '@types/react':
         specifier: 18.2.79


### PR DESCRIPTION
## Summary

This PR reduces external dependencies on the Tailwind-Joy package.