### PR TITLE
refactor(core): Uses color variables in Tailwind CSS v4 format

### DIFF
--- a/packages/tailwind-joy/src/base/modifier.ts
+++ b/packages/tailwind-joy/src/base/modifier.ts
@@ -89,6 +89,6 @@ export function toVariableClass(
 ): string {
   return token.replace(
     /(joy-[a-z0-9]+-[a-z0-9]+)/g,
-    `[--${variableName}:var(--$1)]`,
+    `[--${variableName}:var(--color-$1)]`,
   );
 }

--- a/packages/tailwind-joy/src/components/Divider.tsx
+++ b/packages/tailwind-joy/src/components/Divider.tsx
@@ -27,8 +27,8 @@ function dividerRootVariants(props?: {
     clsx([
       'tj-divider-root group/tj-divider',
       '[--Divider-thickness:1px]',
-      '[--Divider-lineColor:color-mix(in_srgb,var(--joy-neutral-500)_20%,transparent)]',
-      'dark:[--Divider-lineColor:color-mix(in_srgb,var(--joy-neutral-500)_16%,transparent)]',
+      '[--Divider-lineColor:color-mix(in_srgb,var(--color-joy-neutral-500)_20%,transparent)]',
+      'dark:[--Divider-lineColor:color-mix(in_srgb,var(--color-joy-neutral-500)_16%,transparent)]',
       inset === 'none'
         ? '[--_Divider-inset:0px]'
         : '[--_Divider-inset:var(--Divider-inset,0px)]',

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -169,15 +169,15 @@ function inputRootVariants(
       '[--Input-focused:0]',
       '[--Input-focusedThickness:2px]',
       color === 'neutral'
-        ? '[--Input-focusedHighlight:var(--joy-primary-500)]'
-        : `[--Input-focusedHighlight:var(--joy-${color}-500)]`,
+        ? '[--Input-focusedHighlight:var(--color-joy-primary-500)]'
+        : `[--Input-focusedHighlight:var(--color-joy-${color}-500)]`,
       addPrefix(
         clsx([
           instanceColor &&
             (instanceColor === 'neutral'
-              ? '[--_Input-focusedHighlight:var(--joy-primary-500)]'
-              : `[--_Input-focusedHighlight:var(--joy-${instanceColor}-500)]`),
-          r`[--Input-focusedHighlight:var(--\_Input-focusedHighlight,var(--joy-primary-500))]`,
+              ? '[--_Input-focusedHighlight:var(--color-joy-primary-500)]'
+              : `[--_Input-focusedHighlight:var(--color-joy-${instanceColor}-500)]`),
+          r`[--Input-focusedHighlight:var(--\_Input-focusedHighlight,var(--color-joy-primary-500))]`,
         ]),
         '[&:not([data-skip-inverted-colors])]:',
       ),

--- a/packages/tailwind-joy/src/components/Textarea.tsx
+++ b/packages/tailwind-joy/src/components/Textarea.tsx
@@ -70,15 +70,15 @@ function textareaRootVariants(
       '[--Textarea-focused:0]',
       '[--Textarea-focusedThickness:2px]',
       color === 'neutral'
-        ? '[--Textarea-focusedHighlight:var(--joy-primary-500)]'
-        : `[--Textarea-focusedHighlight:var(--joy-${color}-500)]`,
+        ? '[--Textarea-focusedHighlight:var(--color-joy-primary-500)]'
+        : `[--Textarea-focusedHighlight:var(--color-joy-${color}-500)]`,
       addPrefix(
         clsx([
           instanceColor &&
             (instanceColor === 'neutral'
-              ? '[--_Textarea-focusedHighlight:var(--joy-primary-500)]'
-              : `[--_Textarea-focusedHighlight:var(--joy-${instanceColor}-500)]`),
-          r`[--Textarea-focusedHighlight:var(--\_Textarea-focusedHighlight,var(--joy-primary-500))]`,
+              ? '[--_Textarea-focusedHighlight:var(--color-joy-primary-500)]'
+              : `[--_Textarea-focusedHighlight:var(--color-joy-${instanceColor}-500)]`),
+          r`[--Textarea-focusedHighlight:var(--\_Textarea-focusedHighlight,var(--color-joy-primary-500))]`,
         ]),
         '[&:not([data-inverted-colors="false"])]:',
       ),

--- a/packages/tailwind-joy/src/tw-extension.ts
+++ b/packages/tailwind-joy/src/tw-extension.ts
@@ -104,6 +104,8 @@ export const tjPlugin = plugin(
     addBase({
       ':root': {
         '--pi': '3.1415926535',
+        ...Object.fromEntries(convertColorsToEntries(joyColors, '--color-joy')),
+        // deprecated
         ...Object.fromEntries(convertColorsToEntries(joyColors, '--joy')),
       },
     });


### PR DESCRIPTION
## Summary

This PR replaces color variable names with Tailwind CSS v4 format.

I didn't remove the legacy names for compatibility reasons, but future components will use the v4 format names.