### PR TITLE
refactor(core): Use a custom hover variant that can replace the default hover variant

### DIFF
--- a/packages/tailwind-joy/src/base/modifier.ts
+++ b/packages/tailwind-joy/src/base/modifier.ts
@@ -28,7 +28,7 @@ export function addPrefix(
  * A shortcut for the `addPrefix` function.
  */
 export function hover(classNameOrToken: string): string {
-  return addPrefix(classNameOrToken, 'non-touchscreen:hover:');
+  return addPrefix(classNameOrToken, 'non-touchscreen-hover:');
 }
 
 /**

--- a/packages/tailwind-joy/src/components/ButtonGroup.tsx
+++ b/packages/tailwind-joy/src/components/ButtonGroup.tsx
@@ -143,7 +143,7 @@ export function buttonGroupRootVariants(
           ),
           '[&_.tj-button-root:disabled]:',
         ),
-        'non-touchscreen:[&_.tj-button-root:hover]:z-[2]',
+        'non-touchscreen-hover:[&_.tj-button-root]:z-[2]',
         '[&_.tj-button-root:focus-visible]:z-[2]',
       ],
       [
@@ -155,7 +155,7 @@ export function buttonGroupRootVariants(
           ),
           '[&_.tj-icon-button-root:disabled]:',
         ),
-        'non-touchscreen:[&_.tj-icon-button-root:hover]:z-[2]',
+        'non-touchscreen-hover:[&_.tj-icon-button-root]:z-[2]',
         '[&_.tj-icon-button-root:focus-visible]:z-[2]',
       ],
       flexibleButton && [

--- a/packages/tailwind-joy/src/tw-extension.ts
+++ b/packages/tailwind-joy/src/tw-extension.ts
@@ -110,6 +110,11 @@ export const tjPlugin = plugin(
       },
     });
 
+    addVariant(
+      'non-touchscreen-hover',
+      '@media (hover: hover) and (pointer: fine) { &:hover }',
+    );
+    // deprecated
     addVariant('non-touchscreen', '@media (hover: hover) and (pointer: fine)');
   },
 );


### PR DESCRIPTION
## Summary

This PR defines a new hover variant that combines the existing `non-touchscreen` variant with the built-in `hover` variant, and replaces existing code with the new variant.