### PR TITLE
docs(website): Update the installation guide

### DIFF
--- a/apps/website/docs/getting-started/installation.mdx
+++ b/apps/website/docs/getting-started/installation.mdx
@@ -37,13 +37,21 @@ If your project uses TypeScript, you should set the `moduleResolution` property 
 },
 ```
 
-## Extend Tailwind CSS configuration
+## Extend configuration
 
-Tailwind-Joy does not export CSS; instead, the class name of the Tailwind CSS syntax is embedded in the component's `className` property.
+Tailwind-Joy's components have the utility class name embedded in their `className` property.
 
 Therefore, you need to extend the Tailwind CSS configuration to make the components of Tailwind-Joy as if they were part of your project.
 
-### Import module
+:::info
+
+Integration with Tailwind CSS v4 is coming soon.
+
+:::
+
+### Tailwind CSS v3
+
+#### Import module
 
 <Tabs>
 <TabItem value="CJS">
@@ -64,7 +72,7 @@ import { tjClassNames, tjTheme, tjPlugin } from 'tailwind-joy/tw-extension';
 </TabItem>
 </Tabs>
 
-### Extend `content`
+#### Extend `content`
 
 ```tsx
 {
@@ -75,7 +83,7 @@ import { tjClassNames, tjTheme, tjPlugin } from 'tailwind-joy/tw-extension';
 }
 ```
 
-### Extend `theme`
+#### Extend `theme`
 
 ```tsx
 {
@@ -101,7 +109,7 @@ import { tjClassNames, tjTheme, tjPlugin } from 'tailwind-joy/tw-extension';
 }
 ```
 
-### Extend `plugins`
+#### Extend `plugins`
 
 ```tsx
 {


### PR DESCRIPTION
## Summary

This PR removes the phrase "does not export CSS" from the install guide and adds a header that identifies the Tailwind CSS version.