### PR TITLE
refactor(core): Conditionally use class names that changed in Tailwind CSS v4

### DIFF
--- a/packages/tailwind-joy/src/base/utils.ts
+++ b/packages/tailwind-joy/src/base/utils.ts
@@ -1,3 +1,12 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
+export function isTailwindVersion4() {
+  return defaultTheme.transitionProperty.colors.includes(
+    // NOTE: Added in tailwindcss@4.0.0-beta.10.
+    'outline-color',
+  );
+}
+
 export function excludeClassName<T extends Record<string, unknown>>(
   slotProps: T,
 ): {

--- a/packages/tailwind-joy/src/components/Button.tsx
+++ b/packages/tailwind-joy/src/components/Button.tsx
@@ -22,7 +22,7 @@ import type {
   BaseVariants,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 import { ButtonGroupContext } from './ButtonGroup';
 import { CircularProgress } from './CircularProgress';
 import { ToggleButtonGroupContext } from './ToggleButtonGroup';
@@ -72,6 +72,7 @@ function buttonLoadingIndicatorCenterVariants(
 
 function buttonRootVariants(
   props?: BaseVariants & {
+    isTailwind4?: boolean;
     fullWidth?: boolean;
     invisibleChildren?: boolean;
     visuallyDisabled?: boolean;
@@ -81,6 +82,7 @@ function buttonRootVariants(
     color = 'primary',
     size = 'md',
     variant = 'solid',
+    isTailwind4 = false,
     fullWidth = false,
     invisibleChildren = false,
     visuallyDisabled = false,
@@ -100,7 +102,9 @@ function buttonRootVariants(
         '[--Button-gap:0.375rem]',
         'min-h-[var(--Button-minHeight,2rem)]',
         'text-[0.875rem]',
-        '[padding-block:var(--Button-paddingBlock,0.25rem)]',
+        isTailwind4
+          ? 'py-[var(--Button-paddingBlock,0.25rem)]'
+          : '[padding-block:var(--Button-paddingBlock,0.25rem)]',
         'ps-[0.75rem] pe-[0.75rem]',
       ],
       size === 'md' && [
@@ -110,7 +114,9 @@ function buttonRootVariants(
         '[--Button-gap:0.5rem]',
         'min-h-[var(--Button-minHeight,2.25rem)]',
         'text-[0.875rem]',
-        '[padding-block:var(--Button-paddingBlock,0.375rem)]',
+        isTailwind4
+          ? 'py-[var(--Button-paddingBlock,0.375rem)]'
+          : '[padding-block:var(--Button-paddingBlock,0.375rem)]',
         'ps-[1rem] pe-[1rem]',
       ],
       size === 'lg' && [
@@ -120,7 +126,9 @@ function buttonRootVariants(
         '[--Button-gap:0.75rem]',
         'min-h-[var(--Button-minHeight,2.75rem)]',
         'text-[1rem]',
-        '[padding-block:var(--Button-paddingBlock,0.5rem)]',
+        isTailwind4
+          ? 'py-[var(--Button-paddingBlock,0.5rem)]'
+          : '[padding-block:var(--Button-paddingBlock,0.5rem)]',
         'ps-[1.5rem] pe-[1.5rem]',
       ],
       '[-webkit-tap-highlight-color:transparent]',
@@ -264,6 +272,7 @@ function ButtonRoot<T extends ReactTags = 'button'>(
           color: refinedColor,
           fullWidth,
           size: refinedSize,
+          isTailwind4: isTailwindVersion4(),
           variant: refinedVariant,
           invisibleChildren: loading && loadingPosition === 'center',
           visuallyDisabled: refinedDisabled,
@@ -376,6 +385,7 @@ export const generatorInputs: GeneratorInput[] = [
       color: ['primary', 'neutral', 'danger', 'success', 'warning'],
       size: ['sm', 'md', 'lg'],
       variant: ['solid', 'soft', 'outlined', 'plain'],
+      isTailwind4: [false, true],
       fullWidth: [false, true],
       invisibleChildren: [false, true],
       visuallyDisabled: [false, true],

--- a/packages/tailwind-joy/src/components/Divider.tsx
+++ b/packages/tailwind-joy/src/components/Divider.tsx
@@ -10,14 +10,16 @@ import type {
   Difference,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 
 function dividerRootVariants(props?: {
+  isTailwind4?: boolean;
   hasChildren?: boolean;
   inset?: 'none' | 'context';
   orientation?: 'horizontal' | 'vertical';
 }) {
   const {
+    isTailwind4 = false,
     hasChildren = false,
     inset = 'none',
     orientation = 'horizontal',
@@ -36,11 +38,13 @@ function dividerRootVariants(props?: {
       orientation === 'vertical'
         ? [
             'ms-[initial] me-[initial]',
-            r`[margin-block:var(--\_Divider-inset)]`,
+            isTailwind4
+              ? r`my-[var(--\_Divider-inset)]`
+              : r`[margin-block:var(--\_Divider-inset)]`,
           ]
         : [
             r`ms-[var(--\_Divider-inset)] me-[var(--\_Divider-inset)]`,
-            '[margin-block:initial]',
+            isTailwind4 ? 'my-[initial]' : '[margin-block:initial]',
           ],
       'relative',
       'self-stretch',
@@ -176,6 +180,7 @@ function DividerRoot<T extends ReactTags = 'hr'>(
       ref,
       className: twMerge(
         dividerRootVariants({
+          isTailwind4: isTailwindVersion4(),
           hasChildren,
           inset,
           orientation,
@@ -198,6 +203,7 @@ export const generatorInputs: GeneratorInput[] = [
   {
     generatorFn: dividerRootVariants,
     variants: {
+      isTailwind4: [false, true],
       hasChildren: [false, true],
       inset: ['none', 'context'],
       orientation: ['horizontal', 'vertical'],

--- a/packages/tailwind-joy/src/components/IconButton.tsx
+++ b/packages/tailwind-joy/src/components/IconButton.tsx
@@ -21,7 +21,7 @@ import type {
   BaseVariants,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 import { ButtonGroupContext } from './ButtonGroup';
 import { CircularProgress } from './CircularProgress';
 import { ToggleButtonGroupContext } from './ToggleButtonGroup';
@@ -47,6 +47,7 @@ function iconButtonLoadingIndicatorVariants(
 
 export function iconButtonRootVariants(
   props?: BaseVariants & {
+    isTailwind4?: boolean;
     /**
      * The explicit `size` provided to the component.
      */
@@ -58,6 +59,7 @@ export function iconButtonRootVariants(
     color = 'neutral',
     size,
     variant = 'plain',
+    isTailwind4 = false,
     instanceSize,
     visuallyDisabled = false,
   } = props ?? {};
@@ -102,7 +104,7 @@ export function iconButtonRootVariants(
         'ps-[0.375rem] pe-[0.375rem]',
       ],
       '[-webkit-tap-highlight-color:transparent]',
-      '[padding-block:0]',
+      isTailwind4 ? 'py-0' : '[padding-block:0]',
       'font-medium',
       'm-[var(--IconButton-margin)]',
       'rounded-[var(--IconButton-radius,6px)]',
@@ -233,8 +235,9 @@ function IconButtonRoot<T extends ReactTags = 'button'>(
         iconButtonRootVariants({
           color: refinedColor,
           size: refinedSize,
-          instanceSize: size,
           variant: refinedVariant,
+          isTailwind4: isTailwindVersion4(),
+          instanceSize: size,
           visuallyDisabled: refinedDisabled,
         }),
         className,
@@ -318,6 +321,7 @@ export const generatorInputs: GeneratorInput[] = [
       color: ['primary', 'neutral', 'danger', 'success', 'warning'],
       size: [undefined, 'sm', 'md', 'lg'],
       variant: ['solid', 'soft', 'outlined', 'plain'],
+      isTailwind4: [false, true],
       instanceSize: [undefined, 'sm', 'md', 'lg'],
       visuallyDisabled: [false, true],
     },

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -17,7 +17,7 @@ import type {
   BaseVariants,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 
 type PassingProps = Pick<
   ComponentProps<'input'>,
@@ -75,17 +75,22 @@ function inputEndDecoratorVariants() {
 }
 
 function inputInputVariants(props?: {
+  isTailwind4?: boolean;
   hasStartDecorator?: boolean;
   hasEndDecorator?: boolean;
 }) {
-  const { hasStartDecorator = false, hasEndDecorator = false } = props ?? {};
+  const {
+    isTailwind4 = false,
+    hasStartDecorator = false,
+    hasEndDecorator = false,
+  } = props ?? {};
 
   return twMerge(
     clsx([
       'tj-input-input',
       'border-0',
       'min-w-0',
-      'outline-none',
+      isTailwind4 ? 'outline-hidden' : 'outline-none',
       'p-0',
       'flex-1',
       'text-inherit',
@@ -375,6 +380,7 @@ function InputRoot<T extends ReactTags = 'div'>(
       <input
         className={twMerge(
           inputInputVariants({
+            isTailwind4: isTailwindVersion4(),
             hasStartDecorator: Boolean(startDecorator),
             hasEndDecorator: Boolean(endDecorator),
           }),
@@ -432,6 +438,7 @@ export const generatorInputs: GeneratorInput[] = [
   {
     generatorFn: inputInputVariants,
     variants: {
+      isTailwind4: [false, true],
       hasStartDecorator: [false, true],
       hasEndDecorator: [false, true],
     },

--- a/packages/tailwind-joy/src/components/Input.tsx
+++ b/packages/tailwind-joy/src/components/Input.tsx
@@ -40,7 +40,9 @@ type PassingProps = Pick<
   | 'value'
 >;
 
-function inputStartDecoratorVariants() {
+function inputStartDecoratorVariants(props?: { isTailwind4?: boolean }) {
+  const { isTailwind4 = false } = props ?? {};
+
   return twMerge(
     clsx([
       'tj-input-start-decorator',
@@ -49,7 +51,9 @@ function inputStartDecoratorVariants() {
       '[--Icon-margin:0_0_0_calc(var(--Input-paddingInline)/-4)]',
       '[display:inherit]',
       'items-center',
-      r`[padding-block:var(--unstable\_InputPaddingBlock)]`,
+      isTailwind4
+        ? r`py-[var(--unstable\_InputPaddingBlock)]`
+        : r`[padding-block:var(--unstable\_InputPaddingBlock)]`,
       'flex-wrap',
       'me-[var(--Input-gap)]',
       'text-[color:var(--Input-decoratorColor)]',
@@ -369,7 +373,9 @@ function InputRoot<T extends ReactTags = 'div'>(
       {startDecorator && (
         <div
           className={twMerge(
-            inputStartDecoratorVariants(),
+            inputStartDecoratorVariants({
+              isTailwind4: isTailwindVersion4(),
+            }),
             slotProps.startDecorator?.className ?? '',
           )}
           {...(slotPropsWithoutClassName.startDecorator ?? {})}
@@ -429,7 +435,9 @@ export const Input = forwardRef(InputRoot) as <T extends ReactTags = 'div'>(
 export const generatorInputs: GeneratorInput[] = [
   {
     generatorFn: inputStartDecoratorVariants,
-    variants: {},
+    variants: {
+      isTailwind4: [false, true],
+    },
   },
   {
     generatorFn: inputEndDecoratorVariants,

--- a/packages/tailwind-joy/src/components/Textarea.tsx
+++ b/packages/tailwind-joy/src/components/Textarea.tsx
@@ -49,6 +49,7 @@ type PassingProps = Pick<
 
 function textareaRootVariants(
   props?: BaseVariants & {
+    isTailwind4?: boolean;
     instanceColor?: BaseVariants['color'];
   },
 ) {
@@ -56,6 +57,7 @@ function textareaRootVariants(
     color = 'neutral',
     size = 'md',
     variant = 'outlined',
+    isTailwind4 = false,
     instanceColor,
   } = props ?? {};
 
@@ -121,7 +123,9 @@ function textareaRootVariants(
       'flex',
       'flex-col',
       'ps-[var(--Textarea-paddingInline)]',
-      '[padding-block:var(--Textarea-paddingBlock)]',
+      isTailwind4
+        ? 'py-[var(--Textarea-paddingBlock)]'
+        : '[padding-block:var(--Textarea-paddingBlock)]',
       'rounded-[var(--Textarea-radius)]',
       size === 'sm' && [
         'text-[0.875rem]',
@@ -415,6 +419,7 @@ function TextareaRoot<T extends ReactTags = 'div'>(
           color: color ?? (error ? 'danger' : 'neutral'),
           size,
           variant,
+          isTailwind4: isTailwindVersion4(),
           instanceColor: error ? 'danger' : color,
         }),
         className,
@@ -528,6 +533,7 @@ export const generatorInputs: GeneratorInput[] = [
       color: ['primary', 'neutral', 'danger', 'success', 'warning'],
       size: ['sm', 'md', 'lg'],
       variant: ['solid', 'soft', 'outlined', 'plain'],
+      isTailwind4: [false, true],
       instanceColor: [
         undefined,
         'primary',

--- a/packages/tailwind-joy/src/components/Textarea.tsx
+++ b/packages/tailwind-joy/src/components/Textarea.tsx
@@ -25,7 +25,7 @@ import type {
   BaseVariants,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 
 type PassingProps = Pick<
   ComponentProps<'textarea'>,
@@ -178,14 +178,16 @@ function textareaRootVariants(
   );
 }
 
-function textareaInputVariants() {
+function textareaInputVariants(props?: { isTailwind4?: boolean }) {
+  const { isTailwind4 = false } = props ?? {};
+
   return twMerge(
     clsx([
       'tj-textarea-input',
       'resize-none',
       'border-0',
       'min-w-0',
-      'outline-none',
+      isTailwind4 ? 'outline-hidden' : 'outline-none',
       'p-0',
       'pe-[var(--Textarea-paddingInline)]',
       'flex-auto',
@@ -435,7 +437,9 @@ function TextareaRoot<T extends ReactTags = 'div'>(
       )}
       <textarea
         className={twMerge(
-          textareaInputVariants(),
+          textareaInputVariants({
+            isTailwind4: isTailwindVersion4(),
+          }),
           slotProps.textarea?.className ?? '',
         )}
         {...{
@@ -476,7 +480,9 @@ function TextareaRoot<T extends ReactTags = 'div'>(
       <textarea
         ref={shadowRef}
         className={twMerge(
-          textareaInputVariants(),
+          textareaInputVariants({
+            isTailwind4: isTailwindVersion4(),
+          }),
           slotProps.textarea?.className ?? '',
         )}
         aria-hidden
@@ -534,7 +540,9 @@ export const generatorInputs: GeneratorInput[] = [
   },
   {
     generatorFn: textareaInputVariants,
-    variants: {},
+    variants: {
+      isTailwind4: [false, true],
+    },
   },
   {
     generatorFn: textareaStartDecoratorVariants,

--- a/packages/tailwind-joy/src/components/Typography.tsx
+++ b/packages/tailwind-joy/src/components/Typography.tsx
@@ -19,7 +19,7 @@ import type {
   BaseVariants,
   GeneratorInput,
 } from '../base/types';
-import { excludeClassName } from '../base/utils';
+import { isTailwindVersion4, excludeClassName } from '../base/utils';
 
 export type TypographyLevel =
   | 'h1'
@@ -74,6 +74,7 @@ function typographyEndDecoratorVariants() {
 
 function typographyRootVariants(
   props?: Pick<BaseVariants, 'color' | 'variant'> & {
+    isTailwind4?: boolean;
     gutterBottom?: boolean;
     hasEndDecorator?: boolean;
     hasSkeleton?: boolean;
@@ -86,6 +87,7 @@ function typographyRootVariants(
   const {
     color,
     variant,
+    isTailwind4 = false,
     gutterBottom = false,
     hasEndDecorator = false,
     hasSkeleton = false,
@@ -122,7 +124,7 @@ function typographyRootVariants(
         ),
       variant && [
         'rounded-[2px]',
-        '[padding-block:min(0.1em,4px)]',
+        isTailwind4 ? 'py-[min(0.1em,4px)]' : '[padding-block:min(0.1em,4px)]',
         'ps-[0.25em] pe-[0.25em]',
         !nesting && 'ms-[-0.25em] me-[-0.25em]',
         color && theme.variants[variant][color].className,
@@ -215,6 +217,7 @@ function TypographyRoot<T extends ReactTags = 'span'>(
             typographyRootVariants({
               color: instanceColor,
               variant,
+              isTailwind4: isTailwindVersion4(),
               gutterBottom,
               hasEndDecorator: Boolean(endDecorator),
               hasSkeleton,
@@ -291,6 +294,7 @@ export const generatorInputs: GeneratorInput[] = [
     variants: {
       color: [undefined, 'primary', 'neutral', 'danger', 'success', 'warning'],
       variant: [undefined, 'solid', 'soft', 'outlined', 'plain'],
+      isTailwind4: [false, true],
       gutterBottom: [false, true],
       hasEndDecorator: [false, true],
       hasSkeleton: [false, true],


### PR DESCRIPTION
## Summary

This PR introduces a function to determine the version of Tailwind CSS at runtime. And output some class names that changed in Tailwind CSS v4 to match user's version.