### PR TITLE
fix(core): Fix nested variants of aspect ratio component

### DIFF
--- a/packages/tailwind-joy/src/components/AspectRatio.tsx
+++ b/packages/tailwind-joy/src/components/AspectRatio.tsx
@@ -86,16 +86,16 @@ function aspectRatioContentVariants(
           '[object-fit:var(--tj-AspectRatio-objectFit)]',
           'm-0',
           'p-0',
-          addPrefix(
-            clsx([
-              'w-full',
-              'h-full',
-              '[object-fit:var(--tj-AspectRatio-objectFit)]',
-            ]),
-            '[&>img]:',
-          ),
         ]),
         '[&_[data-first-child]]:',
+      ),
+      addPrefix(
+        clsx([
+          'w-full',
+          'h-full',
+          '[object-fit:var(--tj-AspectRatio-objectFit)]',
+        ]),
+        '[&_[data-first-child]>img]:',
       ),
       theme.typography['body-md'].className,
       theme.variants[variant][color].className,


### PR DESCRIPTION
## Summary

This PR fixes visual differences with Joy UI that occur when using `<picture><img /></picture>` as children of an aspect ratio component.